### PR TITLE
Emit provider.healthcheck audit events with error_type metadata

### DIFF
--- a/src/agentic_primitives_gateway/audit/models.py
+++ b/src/agentic_primitives_gateway/audit/models.py
@@ -205,6 +205,15 @@ class AuditAction:
     # evaluations / tasks / observability.
     PROVIDER_CALL = "provider.call"
 
+    # Provider healthcheck outcome — emitted by the /readyz and
+    # /api/v1/providers/status routes for every (primitive, provider) pair.
+    # Distinct from ``provider.call`` so dashboards can filter connection
+    # failures (bad credentials, unreachable backend, dim mismatch, etc.)
+    # without wading through every primitive RPC.  ``metadata`` carries
+    # ``primitive``, ``provider``, ``status`` (ok|reachable|down|timeout),
+    # and ``error_type`` + truncated ``error_message`` on failure.
+    PROVIDER_HEALTHCHECK = "provider.healthcheck"
+
     # Resource access control
     RESOURCE_ACCESS_DENIED = "resource.access.denied"
 

--- a/src/agentic_primitives_gateway/routes/health.py
+++ b/src/agentic_primitives_gateway/routes/health.py
@@ -1,9 +1,12 @@
 import asyncio
 import logging
+from typing import Any
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from agentic_primitives_gateway.audit.emit import emit_audit_event
+from agentic_primitives_gateway.audit.models import AuditAction, AuditOutcome
 from agentic_primitives_gateway.config import settings
 from agentic_primitives_gateway.metrics import PROVIDER_HEALTH
 from agentic_primitives_gateway.models.enums import HealthStatus
@@ -65,6 +68,37 @@ async def whoami() -> dict:
     }
 
 
+def _emit_healthcheck_event(
+    primitive: str,
+    provider_name: str,
+    status: str,
+    *,
+    exc: BaseException | None = None,
+) -> None:
+    """Emit a ``provider.healthcheck`` audit event.
+
+    ``status`` ∈ ``{"ok", "reachable", "down", "timeout"}``.  When ``exc``
+    is set (i.e. the provider raised), ``error_type`` and a truncated
+    ``error_message`` land in metadata so operators can see *why* the
+    backend is unreachable without digging through server logs.
+    """
+    healthy = status in {"ok", "reachable"}
+    metadata: dict[str, Any] = {
+        "primitive": primitive,
+        "provider": provider_name,
+        "status": status,
+    }
+    if exc is not None:
+        metadata["error_type"] = type(exc).__name__
+        metadata["error_message"] = str(exc)[:512]
+    emit_audit_event(
+        action=AuditAction.PROVIDER_HEALTHCHECK,
+        outcome=AuditOutcome.SUCCESS if healthy else AuditOutcome.FAILURE,
+        resource_id=f"{primitive}/{provider_name}",
+        metadata=metadata,
+    )
+
+
 async def _check_provider(primitive: str, provider_name: str) -> tuple[str, str, str, str]:
     """Run a single provider healthcheck with a timeout.
 
@@ -83,19 +117,22 @@ async def _check_provider(primitive: str, provider_name: str) -> tuple[str, str,
     loop = asyncio.get_running_loop()
     task = asyncio.ensure_future(loop.run_in_executor(None, lambda: asyncio.run(provider.healthcheck())))
 
+    exc: BaseException | None = None
     done, _ = await asyncio.wait({task}, timeout=_HEALTHCHECK_TIMEOUT)
     if done:
         try:
             result = task.result()
             # Providers can return bool or str ("ok"/"reachable")
             status = result if isinstance(result, str) else "ok" if result else "down"
-        except Exception:
+        except Exception as e:
             logger.debug("Healthcheck failed: %s", key, exc_info=True)
             status = "down"
+            exc = e
     else:
         logger.debug("Healthcheck timed out: %s", key)
-        status = "down"
+        status = "timeout"
 
+    _emit_healthcheck_event(primitive, provider_name, status, exc=exc)
     return primitive, provider_name, key, status
 
 
@@ -162,15 +199,18 @@ async def _check_provider_authenticated(primitive: str, provider_name: str) -> t
     provider = registry.get_primitive(primitive).get(provider_name)
     key = f"{primitive}/{provider_name}"
 
+    exc: BaseException | None = None
     try:
         result = await asyncio.wait_for(provider.healthcheck(), timeout=_HEALTHCHECK_TIMEOUT)
         status = result if isinstance(result, str) else "ok" if result else "down"
     except TimeoutError:
-        status = "down"
-    except Exception:
+        status = "timeout"
+    except Exception as e:
         logger.debug("Authenticated healthcheck failed: %s", key, exc_info=True)
         status = "down"
+        exc = e
 
+    _emit_healthcheck_event(primitive, provider_name, status, exc=exc)
     return primitive, provider_name, key, status
 
 

--- a/tests/unit/routes/test_health_provider_status.py
+++ b/tests/unit/routes/test_health_provider_status.py
@@ -116,7 +116,10 @@ class TestCheckProviderAuthenticated:
             result = await _check_provider_authenticated("memory", "default")
 
         _, _, _, status = result
-        assert status == "down"
+        # Timeouts are reported distinctly from generic "down" so audit
+        # events + dashboards can distinguish hung backends from connection
+        # failures.  Both still map to outcome=failure at the audit layer.
+        assert status == "timeout"
 
     @pytest.mark.asyncio
     async def test_returns_correct_key_format(self):


### PR DESCRIPTION
Today when a provider's `healthcheck()` fails, `/readyz` and `/api/v1/providers/status` log at `DEBUG` and report `"down"` — but the audit stream gets nothing.  Operators see a red dot on the dashboard with no corresponding audit event to tell them *why*, forcing a dig through server logs to find the exception.

Add a typed `PROVIDER_HEALTHCHECK` action to the audit taxonomy and emit it from both the unauthenticated `/readyz` and authenticated `/api/v1/providers/status` check paths.  Metadata carries:
- `primitive` + `provider` (same bounded labels as `provider.call`)
- `status` ∈ `{ok, reachable, down, timeout}`
- `error_type` + truncated `error_message` when the provider raised

Also splits `"timeout"` out of `"down"` as a distinct status — hung backends and connection failures want different pages in practice, and the extra granularity costs nothing at the dashboard layer (both still map to `outcome=failure`).

Backend healthcheck methods that swallow exceptions internally (returning `False` on any error) hide the real failure from the new audit event.  Those can propagate exceptions instead in a follow-up so the generic wrapper captures the specific exception type; not required for this PR to be useful — even without that change, the route layer's `Exception as e` catch still surfaces the type.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
