### PR TITLE
Fail fast with clear error + audit trail on policy engine provisioning failure

### DIFF
--- a/src/agentic_primitives_gateway/enforcement/cedar.py
+++ b/src/agentic_primitives_gateway/enforcement/cedar.py
@@ -82,27 +82,37 @@ class CedarPolicyEnforcer(SyncRunnerMixin, PolicyEnforcer):
             The policy engine ID.
         """
         if self._engine_id:
+            emit_audit_event(
+                action=AuditAction.POLICY_LOAD,
+                outcome=AuditOutcome.SUCCESS,
+                resource_type=ResourceType.POLICY_ENGINE,
+                resource_id=self._engine_id,
+                reason="engine_id_configured",
+                metadata={"source": "configured"},
+            )
             return self._engine_id
 
         policy_provider = registry.policy
 
-        # Look for an existing gateway_enforcement engine
         try:
             engines_result = await policy_provider.list_policy_engines()
-            for eng in engines_result.get("policy_engines", []):
-                if eng.get("name") == self.AUTO_ENGINE_NAME:
-                    eid: str = eng["policy_engine_id"]
-                    self._engine_id = eid
-                    logger.info(
-                        "Found existing enforcement engine: %s (%s)",
-                        self.AUTO_ENGINE_NAME,
-                        eid,
-                    )
-                    return eid
-        except Exception:
-            logger.debug("Could not list engines, will try to create one")
+        except Exception as e:
+            self._emit_engine_provision_failure("engine_list_failed", e)
+            logger.exception("Failed to list existing enforcement engines")
+            raise
 
-        # Create a new one
+        for eng in engines_result.get("policy_engines", []):
+            if eng.get("name") == self.AUTO_ENGINE_NAME:
+                eid: str = eng["policy_engine_id"]
+                self._engine_id = eid
+                logger.info(
+                    "Found existing enforcement engine: %s (%s)",
+                    self.AUTO_ENGINE_NAME,
+                    eid,
+                )
+                self._emit_engine_ready(eid, source="reused")
+                return eid
+
         try:
             result = await policy_provider.create_policy_engine(
                 name=self.AUTO_ENGINE_NAME,
@@ -115,10 +125,60 @@ class CedarPolicyEnforcer(SyncRunnerMixin, PolicyEnforcer):
                 self.AUTO_ENGINE_NAME,
                 eid,
             )
+            self._emit_engine_ready(eid, source="created")
             return eid
-        except Exception:
+        except Exception as e:
+            self._emit_engine_provision_failure("engine_provision_failed", e)
             logger.exception("Failed to auto-provision enforcement engine")
             raise
+
+    def _emit_engine_ready(self, engine_id: str, *, source: str) -> None:
+        """Emit a durable record that enforcement is wired to an engine
+        whose name the gateway controls (auto-provisioned, either reused
+        or just created).
+
+        The configured path does NOT go through this helper — we don't
+        know that engine's name without a describe call, and we don't
+        claim the engine is "ready" (see ensure_engine for that rationale).
+        """
+        emit_audit_event(
+            action=AuditAction.POLICY_LOAD,
+            outcome=AuditOutcome.SUCCESS,
+            resource_type=ResourceType.POLICY_ENGINE,
+            resource_id=engine_id,
+            reason="engine_ready",
+            metadata={
+                "engine_name": self.AUTO_ENGINE_NAME,
+                "source": source,
+            },
+        )
+
+    def _emit_engine_provision_failure(self, reason: str, exc: BaseException) -> None:
+        """Emit a durable failure record before a provisioning exception
+        propagates.
+
+        - Only the error_type class name is recorded — exception str() from
+          boto3 can include endpoint URLs, partial ARNs, or env var names
+          that hint at credential configuration.
+        - ``resource_id`` is deliberately absent (unlike ``load_policies``
+          failure emits which carry ``self._engine_id``): at this point no
+          engine has been confirmed to exist, so there's no honest ID to
+          record. Refusing to invent one keeps the emit truthful.
+        - ``engine_name`` is the engine we were *trying* to provision, not
+          an engine that's been confirmed to exist. On ``engine_list_failed``
+          this means "we failed while looking for this name" rather than
+          "this engine errored."
+        """
+        emit_audit_event(
+            action=AuditAction.POLICY_LOAD,
+            outcome=AuditOutcome.FAILURE,
+            resource_type=ResourceType.POLICY_ENGINE,
+            reason=reason,
+            metadata={
+                "engine_name": self.AUTO_ENGINE_NAME,
+                "error_type": type(exc).__name__,
+            },
+        )
 
     async def authorize(
         self,

--- a/src/agentic_primitives_gateway/main.py
+++ b/src/agentic_primitives_gateway/main.py
@@ -363,10 +363,31 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     enforcer_cls = _load_class(enforcer_cfg.backend)
     enforcer: PolicyEnforcer = enforcer_cls(**enforcer_cfg.config)
 
-    # Auto-provision a scoped engine if supported (Cedar enforcer)
+    # Auto-provision a scoped engine if supported (Cedar enforcer).
+    # Fail fast with a clear operator-facing message if the backing policy
+    # provider is unreachable — a running server with no policy engine would
+    # 403 every request under Cedar's default-deny, which is worse than a
+    # loud startup failure. The enforcer itself emits a policy.load audit
+    # event on provisioning failure so the refusal-to-start is recorded
+    # durably for SIEMs.
     if hasattr(enforcer, "ensure_engine"):
-        engine_id = await enforcer.ensure_engine()
-        await _seed_policies(engine_id)
+        try:
+            engine_id = await enforcer.ensure_engine()
+            await _seed_policies(engine_id)
+        except Exception as exc:
+            # Record only the exception class name. Exception str() from
+            # boto3 and similar SDKs can contain endpoint URLs, partial
+            # ARNs, or env var names that hint at credential configuration
+            # — the full traceback goes through logger.exception below,
+            # which the LogSanitizationFilter scrubs.
+            logger.error(
+                "Policy enforcement engine could not be provisioned (%s). "
+                "Check that the policy provider's credentials are valid "
+                "(e.g., AWS credentials for the AgentCore policy provider) "
+                "or disable enforcement in config.",
+                type(exc).__name__,
+            )
+            raise
 
     await enforcer.load_policies()
     if hasattr(enforcer, "start_refresh"):

--- a/tests/unit/enforcement/test_cedar.py
+++ b/tests/unit/enforcement/test_cedar.py
@@ -220,3 +220,175 @@ class TestCedarPolicyEnforcer:
 
         enforcer = CedarPolicyEnforcer()
         assert isinstance(enforcer, PolicyEnforcer)
+
+
+class TestEnsureEngineAudit:
+    """Every exit path of ensure_engine() must leave a durable audit record.
+
+    Engine provisioning is a security-posture transition; SIEMs need to
+    distinguish configured vs. reused vs. created (so a surprise new
+    engine is visible) and must see a failure event before the process
+    dies on provisioning error.
+    """
+
+    @pytest.fixture
+    def captured_events(self):
+        events: list[dict] = []
+
+        def _capture(**kwargs):
+            events.append(kwargs)
+
+        with patch(
+            "agentic_primitives_gateway.enforcement.cedar.emit_audit_event",
+            side_effect=_capture,
+        ):
+            yield events
+
+    @pytest.mark.asyncio
+    async def test_configured_engine_id_emits_engine_id_configured(self, captured_events):
+        """engine_id supplied via config → emit records that an ID was
+        configured, NOT that the engine is confirmed reachable. No
+        describe call is made, so the emit deliberately does not claim
+        engine_ready, and engine_name is omitted (the configured engine
+        has a name we don't know without a network call).
+        """
+        enforcer = CedarPolicyEnforcer(engine_id="preset-engine")
+
+        # registry.policy should never be touched on this path
+        mock_registry = MagicMock()
+        with patch("agentic_primitives_gateway.enforcement.cedar.registry", mock_registry):
+            result = await enforcer.ensure_engine()
+
+        assert result == "preset-engine"
+        assert len(captured_events) == 1
+        emitted = captured_events[0]
+        assert emitted["outcome"].value == "success"
+        assert emitted["reason"] == "engine_id_configured"
+        assert emitted["resource_id"] == "preset-engine"
+        assert emitted["metadata"]["source"] == "configured"
+        # engine_name is deliberately absent — we don't know the configured
+        # engine's name and must not fabricate one
+        assert "engine_name" not in emitted["metadata"]
+
+    @pytest.mark.asyncio
+    async def test_existing_engine_emits_ready_with_source_reused(self, captured_events):
+        """An existing engine with the auto name is reused → source=reused."""
+        enforcer = CedarPolicyEnforcer()
+
+        mock_policy_provider = AsyncMock()
+        mock_policy_provider.list_policy_engines.return_value = {
+            "policy_engines": [
+                {"name": "some-other-engine", "policy_engine_id": "other-id"},
+                {
+                    "name": CedarPolicyEnforcer.AUTO_ENGINE_NAME,
+                    "policy_engine_id": "existing-id",
+                },
+            ],
+        }
+
+        mock_registry = MagicMock()
+        type(mock_registry).policy = property(lambda self: mock_policy_provider)
+
+        with patch("agentic_primitives_gateway.enforcement.cedar.registry", mock_registry):
+            result = await enforcer.ensure_engine()
+
+        assert result == "existing-id"
+        mock_policy_provider.create_policy_engine.assert_not_called()
+        assert len(captured_events) == 1
+        emitted = captured_events[0]
+        assert emitted["outcome"].value == "success"
+        assert emitted["reason"] == "engine_ready"
+        assert emitted["resource_id"] == "existing-id"
+        assert emitted["metadata"]["source"] == "reused"
+
+    @pytest.mark.asyncio
+    async def test_created_engine_emits_ready_with_source_created(self, captured_events):
+        """No existing engine → create, emit source=created."""
+        enforcer = CedarPolicyEnforcer()
+
+        mock_policy_provider = AsyncMock()
+        mock_policy_provider.list_policy_engines.return_value = {"policy_engines": []}
+        mock_policy_provider.create_policy_engine.return_value = {
+            "policy_engine_id": "new-id",
+        }
+
+        mock_registry = MagicMock()
+        type(mock_registry).policy = property(lambda self: mock_policy_provider)
+
+        with patch("agentic_primitives_gateway.enforcement.cedar.registry", mock_registry):
+            result = await enforcer.ensure_engine()
+
+        assert result == "new-id"
+        assert len(captured_events) == 1
+        emitted = captured_events[0]
+        assert emitted["outcome"].value == "success"
+        assert emitted["reason"] == "engine_ready"
+        assert emitted["resource_id"] == "new-id"
+        assert emitted["metadata"]["source"] == "created"
+
+    @pytest.mark.asyncio
+    async def test_create_failure_emits_failure_and_raises(self, captured_events):
+        """create_policy_engine raising → one failure emit, then re-raise."""
+        enforcer = CedarPolicyEnforcer()
+
+        mock_policy_provider = AsyncMock()
+        mock_policy_provider.list_policy_engines.return_value = {"policy_engines": []}
+        mock_policy_provider.create_policy_engine.side_effect = RuntimeError("credentials expired")
+
+        mock_registry = MagicMock()
+        type(mock_registry).policy = property(lambda self: mock_policy_provider)
+
+        with (
+            patch("agentic_primitives_gateway.enforcement.cedar.registry", mock_registry),
+            pytest.raises(RuntimeError, match="credentials expired"),
+        ):
+            await enforcer.ensure_engine()
+
+        assert len(captured_events) == 1
+        emitted = captured_events[0]
+        assert emitted["outcome"].value == "failure"
+        assert emitted["reason"] == "engine_provision_failed"
+        assert emitted["metadata"]["error_type"] == "RuntimeError"
+        assert emitted["metadata"]["engine_name"] == CedarPolicyEnforcer.AUTO_ENGINE_NAME
+        # No resource_id since no engine was ever created
+        assert emitted.get("resource_id") is None
+
+    @pytest.mark.asyncio
+    async def test_list_failure_propagates_does_not_fallback_to_create(self, captured_events):
+        """list_policy_engines raising must propagate — not fall through
+        to create_policy_engine. A silent fallback could duplicate engines
+        when the list failure is transient and create then succeeds, and
+        it misattributes the failure audit record to a downstream error.
+
+        The failure emit must carry the LIST error_type, not whatever
+        would have come from create, and create must never be called.
+        """
+
+        class ListSpecificError(Exception):
+            pass
+
+        enforcer = CedarPolicyEnforcer()
+
+        mock_policy_provider = AsyncMock()
+        mock_policy_provider.list_policy_engines.side_effect = ListSpecificError("list failed")
+        # create is configured so that, if it were mistakenly called, the
+        # test would see a different error_type in the emit — making the
+        # failure loud.
+        mock_policy_provider.create_policy_engine.side_effect = RuntimeError("create should never run")
+
+        mock_registry = MagicMock()
+        type(mock_registry).policy = property(lambda self: mock_policy_provider)
+
+        with (
+            patch("agentic_primitives_gateway.enforcement.cedar.registry", mock_registry),
+            pytest.raises(ListSpecificError, match="list failed"),
+        ):
+            await enforcer.ensure_engine()
+
+        mock_policy_provider.create_policy_engine.assert_not_called()
+        assert len(captured_events) == 1
+        emitted = captured_events[0]
+        assert emitted["outcome"].value == "failure"
+        assert emitted["reason"] == "engine_list_failed"
+        assert emitted["metadata"]["error_type"] == "ListSpecificError"
+        assert emitted.get("resource_id") is None


### PR DESCRIPTION
When Cedar enforcement can't provision its policy engine at startup (e.g. AgentCore policy provider unreachable), the server used to crash with a raw 30-line botocore traceback and no audit record. Now:

- main.py catches the failure, logs an operator-facing hint ("check AWS credentials or disable enforcement"), and re-raises. No exception str() interpolation in the log line — boto3 error messages can include endpoint URLs, partial ARNs, or env var names.
- cedar.py's ensure_engine emits policy.load audit events on every exit path: SUCCESS with reason=engine_id_configured on the configured path (honest: an ID was supplied, we haven't confirmed the engine exists), SUCCESS with reason=engine_ready + source={reused,created} on the auto-provisioned paths, FAILURE with reason=engine_list_failed or engine_provision_failed before re-raise. SIEMs see the enforcement posture transition even though the server refuses to start.
- list_policy_engines failures now propagate instead of silently falling through to create_policy_engine — a swallowed list failure could cause duplicate engines when the list call fails transiently but create succeeds, and would misattribute the audit failure to the wrong call.

Cedar with no loaded policies default-denies every request, so a "started but enforcement not wired up" server would 403 all traffic silently. Fail-fast makes the misconfiguration immediately visible.

Fixes #17