### PR TITLE
Assign ServerCredentialMode enum, not bare strings/bools, to allow_server_credentials

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,6 +19,7 @@ import pytest
 
 from agentic_primitives_gateway.config import Settings, settings
 from agentic_primitives_gateway.main import app
+from agentic_primitives_gateway.models.enums import ServerCredentialMode
 from agentic_primitives_gateway.registry import registry
 from agentic_primitives_gateway_client import AgenticPlatformClient
 
@@ -117,7 +118,7 @@ def _init_registry(_skip_without_aws_credentials):
     )
     # Patch the global settings singleton so that get_boto3_session() and
     # other helpers that check allow_server_credentials see the test value.
-    settings.allow_server_credentials = "always"
+    settings.allow_server_credentials = ServerCredentialMode.ALWAYS
     registry.initialize(test_settings)
 
 

--- a/tests/integration/llm/test_bedrock.py
+++ b/tests/integration/llm/test_bedrock.py
@@ -17,6 +17,7 @@ import pytest
 import agentic_primitives_gateway.config as _config_module
 from agentic_primitives_gateway.config import Settings
 from agentic_primitives_gateway.main import app
+from agentic_primitives_gateway.models.enums import ServerCredentialMode
 from agentic_primitives_gateway.registry import registry
 from agentic_primitives_gateway_client import AgenticPlatformClient
 
@@ -98,7 +99,7 @@ def _init_registry():
     )
     orig_settings = _config_module.settings
     _config_module.settings = test_settings
-    _config_module.settings.allow_server_credentials = "always"
+    _config_module.settings.allow_server_credentials = ServerCredentialMode.ALWAYS
     registry.initialize(test_settings)
 
     yield

--- a/tests/integration/memory/test_milvus.py
+++ b/tests/integration/memory/test_milvus.py
@@ -22,6 +22,7 @@ import pytest
 import agentic_primitives_gateway.config as _config_module
 from agentic_primitives_gateway.config import Settings
 from agentic_primitives_gateway.main import app
+from agentic_primitives_gateway.models.enums import ServerCredentialMode
 from agentic_primitives_gateway.registry import registry
 from agentic_primitives_gateway_client import AgenticPlatformClient, AgenticPlatformError
 
@@ -117,7 +118,7 @@ def _init_registry():
     )
     orig_settings = _config_module.settings
     _config_module.settings = test_settings
-    _config_module.settings.allow_server_credentials = "always"
+    _config_module.settings.allow_server_credentials = ServerCredentialMode.ALWAYS
     registry.initialize(test_settings)
 
     yield

--- a/tests/unit/core/test_aws_context.py
+++ b/tests/unit/core/test_aws_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi.testclient import TestClient
 
 from agentic_primitives_gateway.context import get_aws_credentials, set_aws_credentials
+from agentic_primitives_gateway.models.enums import ServerCredentialMode
 
 
 class TestAWSCredentialMiddleware:
@@ -76,13 +77,23 @@ class TestAWSCredentialsDataclass:
         assert get_aws_credentials() is None
 
     def test_get_boto3_session_without_creds_raises_when_server_creds_disabled(self) -> None:
-        from agentic_primitives_gateway.context import get_boto3_session
-
-        set_aws_credentials(None)
+        # Force ``allow_server_credentials`` off for the duration of this
+        # test. Integration tests earlier in the run can leave it in the
+        # enabled state (integration/conftest.py uses "always"), so we
+        # can't rely on the module-level default here.
         import pytest
 
-        with pytest.raises(ValueError, match="server credential fallback is disabled"):
-            get_boto3_session(default_region="us-east-1")
+        from agentic_primitives_gateway.config import settings
+        from agentic_primitives_gateway.context import get_boto3_session
+
+        original = settings.allow_server_credentials
+        try:
+            settings.allow_server_credentials = ServerCredentialMode.NEVER
+            set_aws_credentials(None)
+            with pytest.raises(ValueError, match="server credential fallback is disabled"):
+                get_boto3_session(default_region="us-east-1")
+        finally:
+            settings.allow_server_credentials = original
 
     def test_get_boto3_session_without_creds_works_when_server_creds_enabled(self) -> None:
         from agentic_primitives_gateway.config import settings
@@ -90,7 +101,7 @@ class TestAWSCredentialsDataclass:
 
         original = settings.allow_server_credentials
         try:
-            settings.allow_server_credentials = True
+            settings.allow_server_credentials = ServerCredentialMode.ALWAYS
             set_aws_credentials(None)
             session = get_boto3_session(default_region="us-east-1")
             assert session.region_name == "us-east-1"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
