### PR TITLE
Credential modes, pool ACL, override allow-list

### DIFF
--- a/src/agentic_primitives_gateway/agents/checkpoint_utils.py
+++ b/src/agentic_primitives_gateway/agents/checkpoint_utils.py
@@ -111,14 +111,28 @@ def apply_provider_overrides(spec: AgentSpec) -> dict[str, str]:
     the saved state so restore_provider_overrides can put it back after the
     sub-agent finishes. This ensures the coordinator resumes with its own
     providers.
+
+    The merged result is run through the universal override allow-list
+    (``auth.access.filter_allowed_provider_overrides``) before being
+    applied — spec-level overrides are a user-editable field and must
+    not re-inject a key the header-level gate already strips.
     """
+    from agentic_primitives_gateway.auth.access import (
+        ProviderOverrideSource,
+        apply_filtered_provider_overrides,
+    )
+
     prev: dict[str, str] = {}
     for prim in Primitive:
         val = get_provider_override(prim)
         if val:
             prev[prim] = val
     if spec.provider_overrides:
-        set_provider_overrides({**prev, **spec.provider_overrides})
+        apply_filtered_provider_overrides(
+            {**prev, **spec.provider_overrides},
+            source=ProviderOverrideSource.SUB_AGENT_DELEGATION,
+            resource_id=spec.name,
+        )
     return prev
 
 

--- a/src/agentic_primitives_gateway/agents/runner.py
+++ b/src/agentic_primitives_gateway/agents/runner.py
@@ -1110,21 +1110,23 @@ class AgentRunner:
         turns_used: int,
         tools_called: list[str],
     ) -> None:
+        principal = get_authenticated_principal()
+        payload: dict[str, Any] = {
+            "trace_id": trace_id,
+            "name": f"agent:{spec.name}:chat",
+            "input": user_msg,
+            "output": assistant_msg,
+            "metadata": {
+                "agent_name": spec.name,
+                "session_id": session_id,
+                "turns_used": turns_used,
+                "tools_called": tools_called,
+            },
+        }
+        if principal is not None:
+            payload["user_id"] = principal.id
         try:
-            await registry.observability.ingest_trace(
-                {
-                    "trace_id": trace_id,
-                    "name": f"agent:{spec.name}:chat",
-                    "input": user_msg,
-                    "output": assistant_msg,
-                    "metadata": {
-                        "agent_name": spec.name,
-                        "session_id": session_id,
-                        "turns_used": turns_used,
-                        "tools_called": tools_called,
-                    },
-                }
-            )
+            await registry.observability.ingest_trace(payload)
         except Exception:
             logger.debug("Failed to trace conversation for agent %s", spec.name, exc_info=True)
 

--- a/src/agentic_primitives_gateway/audit/models.py
+++ b/src/agentic_primitives_gateway/audit/models.py
@@ -234,6 +234,17 @@ class AuditAction:
     # and ``error_type`` + truncated ``error_message`` on failure.
     PROVIDER_HEALTHCHECK = "provider.healthcheck"
 
+    # Emitted when the gateway attaches its own ambient credentials to a
+    # backend call on behalf of a caller (under ``allow_server_credentials:
+    # fallback`` or ``always`` with no caller-presented creds).  Surfaces
+    # "degraded operation" — the backend sees the gateway's principal, not
+    # the calling user's, so any backend-enforced per-user ACL collapses
+    # to a single shared identity.  Metadata carries ``service`` (e.g.
+    # ``"langfuse"``, ``"aws"``) and ``mode`` (``"fallback"`` or
+    # ``"always"``).  Admin callers are ignored — the event exists to
+    # highlight non-admin requests using shared creds.
+    PROVIDER_SERVER_CREDENTIALS_USED = "provider.server_credentials_used"
+
     # Gateway config hot-reload outcome — emitted by the ConfigWatcher each
     # time the watched YAML's mtime/inode changes and ``registry.reload()``
     # runs. SUCCESS carries ``config_path`` + ``duration_ms`` in metadata;

--- a/src/agentic_primitives_gateway/audit/redaction.py
+++ b/src/agentic_primitives_gateway/audit/redaction.py
@@ -33,20 +33,56 @@ DEFAULT_REDACT_KEYS: frozenset[str] = frozenset(
         "refresh_token",
         "x-aws-secret-access-key",
         "x-aws-session-token",
+        "x-aws-access-key-id",
     }
 )
 
-# Regexes for known secret shapes in free-form log text.
+# Key prefixes whose values are always redacted.  ``X-Cred-*`` is the
+# per-request service-credential convention (``X-Cred-Keycloak-Client-Secret``,
+# ``X-Cred-Langfuse-Public-Key``, etc.) — new backends add new key names
+# without updating this file, so a prefix match is required for coverage
+# to stay honest as the credential surface grows.  ``X-AWS-*`` catches
+# any future AWS header we might add (``X-AWS-Role-Arn`` etc.); the only
+# AWS header that is *not* sensitive (``X-AWS-Region``) is explicitly
+# allowed below.
+REDACT_KEY_PREFIXES: tuple[str, ...] = ("x-cred-", "x-aws-")
+REDACT_KEY_PREFIX_ALLOW: frozenset[str] = frozenset({"x-aws-region"})
+
+# Regexes for known secret shapes in free-form log text.  These fire on
+# application logs and exception tracebacks (via
+# ``LogSanitizationFilter``), catching the string form a credential might
+# appear in when a downstream library raises an error containing the
+# original request header.
 SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
     # Bearer tokens
     re.compile(r"Bearer\s+[A-Za-z0-9\-_\.=]+", re.IGNORECASE),
-    # AWS access key IDs
+    # AWS access key IDs (prefix literal; the actual ID format is 16-char alnum)
     re.compile(r"AKIA[0-9A-Z]{16}"),
     # JWT three-part tokens (rough match — three base64url sections)
     re.compile(r"eyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"),
     # apg.<service>.<key> = <value>
     re.compile(r"apg\.[a-z_]+\.[a-z_]+\s*[:=]\s*\S+", re.IGNORECASE),
+    # X-Cred-<Service>-<Key>: <value> — scrubs the value after the colon
+    # (or equals sign).  Matches through to end-of-line / next whitespace.
+    re.compile(r"(?i)(X-Cred-[A-Za-z0-9\-]+)\s*[:=]\s*\S+"),
+    # X-AWS-Secret-Access-Key: <40-ish chars> and friends.  ``X-AWS-Region``
+    # is excluded on purpose; it isn't a secret.
+    re.compile(r"(?i)(X-AWS-Secret-Access-Key|X-AWS-Session-Token|X-AWS-Access-Key-Id)\s*[:=]\s*\S+"),
+    # Raw ``Authorization: <opaque-token>`` without the ``Bearer`` prefix.
+    # The Bearer variant is already handled above; this catches opaque
+    # API keys passed in the Authorization header.
+    re.compile(r"(?im)^\s*Authorization\s*:\s*(?!Bearer\b)\S+"),
 )
+
+
+def _is_redacted_key(key: str) -> bool:
+    """True if ``key`` matches the default deny-list or a redaction prefix."""
+    low = key.lower()
+    if low in DEFAULT_REDACT_KEYS:
+        return True
+    if low in REDACT_KEY_PREFIX_ALLOW:
+        return False
+    return any(low.startswith(p) for p in REDACT_KEY_PREFIXES)
 
 
 def redact_mapping(
@@ -55,20 +91,25 @@ def redact_mapping(
 ) -> dict[str, Any]:
     """Return a shallow-redacted copy of ``data``.
 
-    Keys matching the default deny-list or ``extra_keys`` (case-insensitive)
-    have their values replaced with ``"***"``.  Nested dicts are walked
-    recursively.  Lists/tuples are returned unchanged — the caller is
-    responsible for not putting secrets into list-valued metadata.
+    Keys matching the default deny-list, an ``X-Cred-*`` / ``X-AWS-*``
+    prefix (with ``X-AWS-Region`` allowed through), or ``extra_keys``
+    (case-insensitive) have their values replaced with ``"***"``.
+    Nested dicts are walked recursively.  Lists/tuples are returned
+    unchanged — the caller is responsible for not putting secrets into
+    list-valued metadata.
     """
-    deny: frozenset[str] = frozenset({k.lower() for k in extra_keys}) | DEFAULT_REDACT_KEYS
-    result = _redact(data, deny)
+    extra: frozenset[str] = frozenset({k.lower() for k in extra_keys})
+    result = _redact(data, extra)
     assert isinstance(result, dict)
     return result
 
 
-def _redact(value: Any, deny: frozenset[str]) -> Any:
+def _redact(value: Any, extra: frozenset[str]) -> Any:
     if isinstance(value, dict):
-        return {k: (REDACTED if k.lower() in deny else _redact(v, deny)) for k, v in value.items()}
+        return {
+            k: (REDACTED if (_is_redacted_key(k) or k.lower() in extra) else _redact(v, extra))
+            for k, v in value.items()
+        }
     return value
 
 

--- a/src/agentic_primitives_gateway/auth/access.py
+++ b/src/agentic_primitives_gateway/auth/access.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from fastapi import HTTPException
 
 from agentic_primitives_gateway import metrics
 from agentic_primitives_gateway.audit.emit import emit_audit_event
 from agentic_primitives_gateway.audit.models import AuditAction, AuditOutcome, ResourceType
 from agentic_primitives_gateway.auth.models import AuthenticatedPrincipal
+
+if TYPE_CHECKING:
+    from agentic_primitives_gateway.agents.store import AgentStore
+    from agentic_primitives_gateway.agents.team_store import TeamStore
 
 
 def check_access(
@@ -105,3 +111,113 @@ def require_owner_or_admin(
         _emit_denial("not_owner", resource_owner, resource_type)
         raise HTTPException(status_code=403, detail="Forbidden")
     return principal
+
+
+# ── Transitive access to shared memory pools ─────────────────────────
+#
+# Shared memory pools are a gateway-authored resource: the gateway
+# decides the pool-name → backend-namespace mapping, and agent specs
+# declare which pools they reference via ``PrimitiveConfig.shared_namespaces``.
+# The REST surface at ``/api/v1/memory/{namespace}/*`` has no native
+# per-pool ACL — without a check, any authenticated caller can read,
+# write, or delete any unscoped namespace by guessing its name.
+#
+# The chosen ACL grain is "transitive through accessible agents / teams":
+# a caller has access to pool ``P`` if they can access some agent whose
+# ``primitives["memory"].shared_namespaces`` contains ``P``, or some team
+# whose ``shared_memory_namespace == P``.  Admin bypasses all checks.
+#
+# Rationale: the tool surface already exposes the same read/write
+# operations against these pools (``pool_memory_store`` / ``_retrieve`` /
+# ``_search`` / ``_list``), so a caller with access to such an agent
+# already has full read/write via the agent-run path.  Granting REST
+# parity for those same callers keeps the two surfaces aligned and does
+# not widen the blast radius.  Delete is REST-only; it is handled by a
+# narrower check (:func:`require_pool_delete`) below.
+#
+# Orphan pools — pools that exist in the backend (e.g. created out of
+# band or left behind after an agent was deleted) but are not declared
+# in any spec visible to the caller — resolve to admin-only under this
+# rule, which is the safer default.
+
+
+async def has_transitive_pool_access(
+    pool: str,
+    *,
+    principal: AuthenticatedPrincipal,
+    agent_store: AgentStore,
+    team_store: TeamStore,
+) -> bool:
+    """Whether ``principal`` can access shared pool ``pool``.
+
+    Admin short-circuits to True.  Otherwise walks specs visible to the
+    principal (via each store's ``list_for_user``) and returns True on
+    the first match.  Pool-level only — does not filter events within
+    the pool.
+    """
+    if principal.is_admin:
+        return True
+    for agent in await agent_store.list_for_user(principal):
+        mem = agent.primitives.get("memory")
+        if mem is not None and mem.shared_namespaces and pool in mem.shared_namespaces:
+            return True
+    return any(team.shared_memory_namespace == pool for team in await team_store.list_for_user(principal))
+
+
+async def require_pool_access(
+    pool: str,
+    *,
+    principal: AuthenticatedPrincipal,
+    agent_store: AgentStore,
+    team_store: TeamStore,
+) -> None:
+    """Raise 403 unless ``principal`` has transitive access to ``pool``.
+
+    Read/write parity with the agent-tool surface.  For destructive
+    operations (``DELETE``) use :func:`require_pool_delete` instead.
+    """
+    if await has_transitive_pool_access(pool, principal=principal, agent_store=agent_store, team_store=team_store):
+        return
+    _emit_denial("pool_not_transitively_accessible", resource_owner="", resource_type="memory_pool")
+    raise HTTPException(status_code=403, detail="Forbidden")
+
+
+async def require_pool_delete(
+    pool: str,
+    *,
+    principal: AuthenticatedPrincipal,
+    agent_store: AgentStore,
+    team_store: TeamStore,
+) -> None:
+    """Raise 403 unless ``principal`` owns a spec that declares ``pool``.
+
+    Narrower than :func:`require_pool_access` — destructive ops go
+    through this.  Admin bypasses.  Otherwise the principal must *own*
+    (not just have shared access to) an agent or team that declares
+    the pool — sharing an agent grants read/write on its pool, but
+    only the owner (or admin) can wipe a key.
+
+    Known operational trade-off: memory records carry no ``written_by``
+    provenance field.  A sharee can write keys that only the owner
+    (or an admin) can later delete — if a pool accumulates garbage
+    from a misbehaving sharee, cleanup is an owner action.  This is
+    deliberate: the alternative ("delete your own writes") would
+    require per-record attribution we don't currently emit, and a
+    less-scoped rule ("any sharee can delete any key") would let a
+    sharee wipe the owner's data, which is strictly worse.
+    """
+    if principal.is_admin:
+        return
+    for agent in await agent_store.list_for_user(principal):
+        if agent.owner_id != principal.id:
+            continue
+        mem = agent.primitives.get("memory")
+        if mem is not None and mem.shared_namespaces and pool in mem.shared_namespaces:
+            return
+    for team in await team_store.list_for_user(principal):
+        if team.owner_id != principal.id:
+            continue
+        if team.shared_memory_namespace == pool:
+            return
+    _emit_denial("pool_delete_requires_owner", resource_owner="", resource_type="memory_pool")
+    raise HTTPException(status_code=403, detail="Forbidden")

--- a/src/agentic_primitives_gateway/auth/access.py
+++ b/src/agentic_primitives_gateway/auth/access.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException
@@ -14,6 +15,22 @@ from agentic_primitives_gateway.auth.models import AuthenticatedPrincipal
 if TYPE_CHECKING:
     from agentic_primitives_gateway.agents.store import AgentStore
     from agentic_primitives_gateway.agents.team_store import TeamStore
+
+
+class ProviderOverrideSource(StrEnum):
+    """Call-site identifier for :func:`apply_filtered_provider_overrides`.
+
+    The value shows up in the ``source`` field of the audit event
+    emitted when overrides are stripped.  Using a ``StrEnum`` instead
+    of a free-form string prevents typos from silently creating new
+    categories in audit dashboards (e.g. ``"agent-run"`` vs
+    ``"agent_run"``).
+    """
+
+    AGENT_RUN = "agent_run"
+    A2A = "a2a"
+    SUB_AGENT_DELEGATION = "sub_agent_delegation"
+    TEST = "test"
 
 
 def check_access(
@@ -221,3 +238,117 @@ async def require_pool_delete(
             return
     _emit_denial("pool_delete_requires_owner", resource_owner="", resource_type="memory_pool")
     raise HTTPException(status_code=403, detail="Forbidden")
+
+
+# ── X-Provider-* override allow-list ─────────────────────────────────
+#
+# Primitives whose ``X-Provider-<primitive>`` override is safe to set
+# at request time — for any caller, admin or otherwise.  Default-deny:
+# new primitives are un-overrideable until someone explicitly audits
+# the routing impact and adds them here.
+#
+# The allow-list is **universal** — not gated on ``is_admin``.  Admins
+# have no legitimate runtime reason to flip identity or policy
+# backends: real deployments (A/B tests, new backend wiring, debugging)
+# are operator work done via startup config or shadow deployments, not
+# request-time header injection.  A universal allow-list keeps the
+# invariant "trust-sensitive primitives cannot be overridden at request
+# time" true regardless of caller scope, and removes the
+# admin-accidentally-overriding-something-they-shouldn't class of bug.
+#
+# Criterion for inclusion: picking a different backend is a routing
+# preference, not a security or capability decision.  A primitive is
+# excluded when:
+#  * backend selection changes what authorisation rule the gateway
+#    enforces (identity: ``supports_user_relay`` differs across
+#    backends; policy: noop policy admits everything), OR
+#  * backend selection changes what code executes (tools: the set of
+#    registered tools can differ between MCP registries and
+#    AgentCore Gateways, which is arbitrary-code-execution
+#    privilege escalation if flipped at request time).
+_PROVIDER_OVERRIDE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "memory",
+        "observability",
+        "llm",
+        "code_interpreter",
+        "browser",
+        "evaluations",
+        "knowledge",
+        "tasks",
+    }
+)
+
+# Defensive: the global ``X-Provider`` header becomes an override with
+# key ``"default"`` at the middleware layer.  Honouring it would affect
+# every primitive, including those deliberately excluded above, so it
+# must never be on the allow-list.  An assert fails fast at import time
+# if a future refactor adds it by mistake.
+assert "default" not in _PROVIDER_OVERRIDE_ALLOWLIST, (
+    "'default' must never be on the provider-override allow-list — it is "
+    "the global X-Provider header key and would override trust-sensitive "
+    "primitives that are otherwise excluded."
+)
+
+
+def filter_allowed_provider_overrides(
+    overrides: dict[str, str],
+) -> tuple[dict[str, str], list[str]]:
+    """Drop overrides that are not on the universal allow-list.
+
+    Returns ``(kept, dropped_keys)``.  The global ``X-Provider``
+    default is never admitted because it would affect the excluded
+    primitives too.
+
+    Used by:
+    - ``AuthenticationMiddleware`` when interpreting request headers;
+    - :func:`apply_filtered_provider_overrides` when applying
+      ``spec.provider_overrides`` from an ``AgentSpec`` — the spec
+      is a user-editable field and an owner could otherwise
+      re-inject an override that the middleware already stripped.
+    """
+    if not overrides:
+        return {}, []
+    kept: dict[str, str] = {}
+    dropped: list[str] = []
+    for k, v in overrides.items():
+        if k in _PROVIDER_OVERRIDE_ALLOWLIST:
+            kept[k] = v
+        else:
+            dropped.append(k)
+    return kept, sorted(dropped)
+
+
+def apply_filtered_provider_overrides(
+    overrides: dict[str, str] | None,
+    *,
+    source: ProviderOverrideSource,
+    resource_id: str | None = None,
+) -> None:
+    """Filter ``overrides`` against the allow-list and apply them.
+
+    Drops any key not on ``_PROVIDER_OVERRIDE_ALLOWLIST`` (silently
+    for the caller; loudly in audit).  Used by every code path that
+    applies ``spec.provider_overrides`` from an ``AgentSpec`` so the
+    header-level gate in the auth middleware can't be bypassed by
+    stashing trust-sensitive overrides in the spec instead.
+
+    ``source`` identifies the call site for the audit event — a
+    :class:`ProviderOverrideSource` value.  ``resource_id`` is the
+    spec name / id the overrides came from, also for audit.
+    """
+    from agentic_primitives_gateway.context import set_provider_overrides
+
+    if not overrides:
+        return
+    kept, dropped = filter_allowed_provider_overrides(overrides)
+    set_provider_overrides(kept)
+    if dropped:
+        emit_audit_event(
+            action=AuditAction.RESOURCE_ACCESS_DENIED,
+            outcome=AuditOutcome.FAILURE,
+            resource_type=ResourceType.SESSION,
+            resource_id=resource_id,
+            reason="spec_provider_override_not_on_allowlist",
+            metadata={"source": str(source), "dropped_overrides": dropped},
+        )

--- a/src/agentic_primitives_gateway/auth/middleware.py
+++ b/src/agentic_primitives_gateway/auth/middleware.py
@@ -11,9 +11,14 @@ from starlette.responses import JSONResponse, Response
 from agentic_primitives_gateway import metrics
 from agentic_primitives_gateway.audit.emit import emit_audit_event
 from agentic_primitives_gateway.audit.models import AuditAction, AuditOutcome, ResourceType
+from agentic_primitives_gateway.auth.access import filter_allowed_provider_overrides
 from agentic_primitives_gateway.auth.base import AuthBackend
-from agentic_primitives_gateway.auth.models import ANONYMOUS_PRINCIPAL, NOOP_PRINCIPAL
-from agentic_primitives_gateway.context import set_authenticated_principal
+from agentic_primitives_gateway.auth.models import ANONYMOUS_PRINCIPAL, NOOP_PRINCIPAL, AuthenticatedPrincipal
+from agentic_primitives_gateway.context import (
+    get_provider_overrides,
+    set_authenticated_principal,
+    set_provider_overrides,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +65,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
         if backend is None:
             set_authenticated_principal(NOOP_PRINCIPAL)
             request.state.principal = NOOP_PRINCIPAL
+            _enforce_provider_override_allowlist(NOOP_PRINCIPAL, request.url.path)
             return await call_next(request)
 
         # Exempt paths get anonymous principal (non-admin) without validation
@@ -68,11 +74,13 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             if path.startswith(prefix):
                 set_authenticated_principal(ANONYMOUS_PRINCIPAL)
                 request.state.principal = ANONYMOUS_PRINCIPAL
+                _enforce_provider_override_allowlist(ANONYMOUS_PRINCIPAL, path)
                 return await call_next(request)
         for suffix in AUTH_EXEMPT_SUFFIXES:
             if path.endswith(suffix):
                 set_authenticated_principal(ANONYMOUS_PRINCIPAL)
                 request.state.principal = ANONYMOUS_PRINCIPAL
+                _enforce_provider_override_allowlist(ANONYMOUS_PRINCIPAL, path)
                 return await call_next(request)
 
         principal = await backend.authenticate(request)
@@ -102,6 +110,7 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
 
         set_authenticated_principal(principal)
         request.state.principal = principal
+        _enforce_provider_override_allowlist(principal, path)
         emit_audit_event(
             action=AuditAction.AUTH_SUCCESS,
             outcome=AuditOutcome.SUCCESS,
@@ -117,3 +126,34 @@ class AuthenticationMiddleware(BaseHTTPMiddleware):
             principal_type=principal.type,
         ).inc()
         return await call_next(request)
+
+
+def _enforce_provider_override_allowlist(principal: AuthenticatedPrincipal, path: str) -> None:
+    """Strip ``X-Provider-*`` overrides that are not on the universal allow-list.
+
+    ``RequestContextMiddleware`` (which runs earlier) populates the
+    provider-override contextvar verbatim from the request headers.
+    The allow-list lives in :mod:`auth.access` and is *universal* —
+    it applies to every caller, admin included.  Request-time backend
+    selection is a routing preference for non-trust-sensitive
+    primitives; for identity / policy / tools / the global default,
+    the configured backend is the authoritative choice and a request
+    header can't override it.  Admins who need to pin a backend for
+    testing use startup config or a shadow deployment, not this path.
+    """
+    overrides = get_provider_overrides()
+    if not overrides:
+        return
+    kept, dropped = filter_allowed_provider_overrides(overrides)
+    if not dropped:
+        return
+    set_provider_overrides(kept)
+    emit_audit_event(
+        action=AuditAction.RESOURCE_ACCESS_DENIED,
+        outcome=AuditOutcome.FAILURE,
+        resource_type=ResourceType.SESSION,
+        resource_id=principal.id,
+        reason="provider_override_not_on_allowlist",
+        http_path=path,
+        metadata={"dropped_overrides": dropped},
+    )

--- a/src/agentic_primitives_gateway/context.py
+++ b/src/agentic_primitives_gateway/context.py
@@ -129,6 +129,11 @@ def set_provider_overrides(overrides: dict[str, str]) -> None:
     _provider_overrides.set(overrides)
 
 
+def get_provider_overrides() -> dict[str, str]:
+    """Return a snapshot of the currently-active provider overrides."""
+    return dict(_provider_overrides.get())
+
+
 def get_provider_override(primitive: str) -> str | None:
     overrides = _provider_overrides.get()
     return overrides.get(primitive) or overrides.get("default")

--- a/src/agentic_primitives_gateway/context.py
+++ b/src/agentic_primitives_gateway/context.py
@@ -212,42 +212,80 @@ def get_service_credentials_or_defaults(
     service: str,
     defaults: dict[str, str | None],
 ) -> dict[str, str | None]:
-    """Get service credentials from context, with optional server-side defaults.
+    """Resolve service config by mode of ``allow_server_credentials``.
 
-    Args:
-        service: Service name (e.g., 'langfuse').
-        defaults: Server-configured default values for this service.
+    Three modes, three rules — no per-key classification, no silent
+    merge paths that mix caller and operator values except in the one
+    mode that is explicitly defined as "allow mixing":
 
-    Returns:
-        Merged credentials (client overrides server defaults).
-
-    Raises:
-        ValueError: If no client credentials and server fallback is disabled,
-            and the defaults contain required values that are None.
+    * ``NEVER`` — caller supplies the entire shape.  ``defaults`` is
+      **not consulted for values**.  We do return a dict keyed on
+      ``defaults.keys()`` so providers that use bracket access don't
+      explode on a missing key; caller-supplied values land on their
+      keys, everything else is ``None``.  If ``client_creds`` is empty
+      we raise — the gateway has no credentials at all and the caller
+      has to know that up-front rather than see a cryptic backend
+      error.
+    * ``ALWAYS`` — operator controls credentials.  Caller-supplied
+      values are ignored entirely; we return ``dict(defaults)``
+      unchanged.  A non-admin caller under this mode triggers the
+      ``provider.server_credentials_used`` event so the degraded
+      state is auditable.
+    * ``FALLBACK`` — merge, caller wins on leaves.  The only mode
+      where mixing is allowed.  If any key in ``defaults`` was filled
+      from the operator side (i.e. the caller didn't supply a truthy
+      value for it), emit ``provider.server_credentials_used`` once.
     """
-    client_creds = get_service_credentials(service) or {}
+    from agentic_primitives_gateway.models.enums import ServerCredentialMode
 
-    # Client credentials take priority
-    merged = dict(defaults)
-    merged.update({k: v for k, v in client_creds.items() if v})
+    client_creds: dict[str, str] = {k: v for k, v in (get_service_credentials(service) or {}).items() if v}
+    mode = _resolve_server_credential_mode()
 
-    # If we got credentials from the client, always allow
-    if client_creds:
-        return merged
-
-    # No client credentials — check if server fallback is allowed
-    if _server_credentials_allowed():
+    if mode == ServerCredentialMode.ALWAYS:
         _emit_server_credentials_used(service)
-        return merged
+        return dict(defaults)
 
-    # Check if the server defaults actually have values
-    has_defaults = any(v for v in defaults.values() if v)
-    if has_defaults:
-        raise ValueError(
-            f"No {service} credentials provided in request headers and server "
-            f"credential fallback is disabled. Either pass credentials via "
-            f"X-Cred-{service.capitalize()}-* headers from the client, or enable "
-            f"server credentials with allow_server_credentials: true in the server config."
-        )
+    if mode == ServerCredentialMode.NEVER:
+        if not client_creds:
+            raise ValueError(
+                f"No {service} credentials provided in request headers and server "
+                f"credential fallback is disabled. Either pass credentials via "
+                f"X-Cred-{service.capitalize()}-* headers from the client, or enable "
+                f"server credentials with allow_server_credentials: fallback in the server config."
+            )
+        # Preserve the shape of ``defaults`` so providers using
+        # bracket access (``cfg["realm"]``) don't raise ``KeyError``
+        # when the caller omits a key.  ``None`` is the signal "not
+        # configured", which providers should already be prepared to
+        # reject on downstream use.
+        shape_preserving: dict[str, str | None] = dict.fromkeys(defaults)
+        shape_preserving.update(client_creds)
+        return shape_preserving
 
+    # FALLBACK — merge with caller winning.  Track which keys the
+    # operator filled so the audit event fires at the right granularity.
+    merged: dict[str, str | None] = dict(defaults)
+    merged.update(client_creds)
+    server_filled = [k for k, v in defaults.items() if v and k not in client_creds]
+    if server_filled:
+        _emit_server_credentials_used(service)
     return merged
+
+
+def _resolve_server_credential_mode() -> Any:
+    """Read ``allow_server_credentials`` and normalise to the enum.
+
+    ``settings.allow_server_credentials`` can be either a bool (legacy)
+    or a :class:`ServerCredentialMode` value.  The three-mode semantics
+    of this module treat a bool as ``ALWAYS`` (``True``) or ``NEVER``
+    (``False``); there is no bool equivalent of ``FALLBACK``.  Config
+    validation converts bools at load time for shipped configs, but
+    we defend here in case an operator sets a bool programmatically.
+    """
+    from agentic_primitives_gateway.config import settings
+    from agentic_primitives_gateway.models.enums import ServerCredentialMode
+
+    mode = settings.allow_server_credentials
+    if isinstance(mode, bool):
+        return ServerCredentialMode.ALWAYS if mode else ServerCredentialMode.NEVER
+    return mode

--- a/src/agentic_primitives_gateway/context.py
+++ b/src/agentic_primitives_gateway/context.py
@@ -150,6 +150,33 @@ def _server_credentials_allowed() -> bool:
     return mode in (ServerCredentialMode.FALLBACK, ServerCredentialMode.ALWAYS)
 
 
+def _emit_server_credentials_used(service: str) -> None:
+    """Emit ``provider.server_credentials_used`` for non-admin callers.
+
+    Admin callers are deliberately excluded — ambient-cred use by admins
+    is the expected operator path.  The event exists to surface the
+    "backend sees one shared principal" state for non-admin requests, so
+    audit consumers can tell when per-user isolation has collapsed.
+    """
+    principal = get_authenticated_principal()
+    if principal is not None and principal.is_admin:
+        return
+
+    from agentic_primitives_gateway.audit.emit import emit_audit_event
+    from agentic_primitives_gateway.audit.models import AuditAction, AuditOutcome, ResourceType
+    from agentic_primitives_gateway.config import settings
+
+    mode = settings.allow_server_credentials
+    mode_str = str(mode.value) if hasattr(mode, "value") else str(mode)
+    emit_audit_event(
+        action=AuditAction.PROVIDER_SERVER_CREDENTIALS_USED,
+        outcome=AuditOutcome.SUCCESS,
+        resource_type=ResourceType.CREDENTIAL,
+        resource_id=service,
+        metadata={"service": service, "mode": mode_str},
+    )
+
+
 def get_boto3_session(default_region: str = "us-east-1") -> Any:
     """Create a boto3 Session from the current request's AWS credentials.
 
@@ -170,6 +197,7 @@ def get_boto3_session(default_region: str = "us-east-1") -> Any:
         )
 
     if _server_credentials_allowed():
+        _emit_server_credentials_used("aws")
         return boto3.Session(region_name=default_region)
 
     raise ValueError(
@@ -209,6 +237,7 @@ def get_service_credentials_or_defaults(
 
     # No client credentials — check if server fallback is allowed
     if _server_credentials_allowed():
+        _emit_server_credentials_used(service)
         return merged
 
     # Check if the server defaults actually have values

--- a/src/agentic_primitives_gateway/main.py
+++ b/src/agentic_primitives_gateway/main.py
@@ -172,6 +172,49 @@ def _warn_replica_unsafe_config() -> None:
         )
 
 
+def _warn_server_credentials_with_real_auth() -> None:
+    """Log a warning when real auth is configured but server creds are shared.
+
+    The combination ``auth.backend in {"jwt","api_key"}`` (multi-user) +
+    ``allow_server_credentials in {"fallback","always"}`` (shared backend
+    creds) means per-user isolation at the backend collapses to a single
+    gateway principal whenever a caller doesn't present their own creds.
+    That's a legitimate operator choice (e.g. "vend one Langfuse project
+    across users"), but it's worth surfacing at startup so operators
+    don't assume the multi-user auth story extends into backend ACLs.
+    No warning under ``noop`` auth (single-user dev mode) or under
+    ``never`` (the safer default we ship).
+    """
+    from agentic_primitives_gateway.models.enums import ServerCredentialMode
+
+    auth_backend = settings.auth.backend
+    if auth_backend == "noop":
+        return  # single-user dev mode — shared creds are expected
+
+    mode = settings.allow_server_credentials
+    if isinstance(mode, bool):
+        uses_shared = mode
+        mode_label = "true" if mode else "false"
+    else:
+        uses_shared = mode in (ServerCredentialMode.FALLBACK, ServerCredentialMode.ALWAYS)
+        mode_label = str(mode.value)
+
+    if not uses_shared:
+        return  # never / false — no ambient creds ever attach
+
+    logger.warning(
+        "Server-credential warning: auth.backend=%r is multi-user, but "
+        "allow_server_credentials=%r lets the gateway fall back to its own "
+        "backend credentials when callers don't present their own.  When "
+        "that fallback fires, the backend sees one shared gateway principal "
+        "for all users — per-user isolation at the backend collapses.  This "
+        "is a supported configuration, but verify it matches your operator "
+        "intent (e.g. a single shared Langfuse project vs. per-user keys).",
+        auth_backend,
+        mode_label,
+    )
+
+
 def _build_audit_router() -> AuditRouter | None:
     """Construct the process-wide ``AuditRouter`` from ``settings.audit``.
 
@@ -216,6 +259,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     logger.info("agentic-primitives-gateway build=%s", BUILD_REF)
     registry.initialize()
     _warn_replica_unsafe_config()
+    _warn_server_credentials_with_real_auth()
 
     # Start the audit router before anything else so emits from the rest of
     # the startup path land on sinks.

--- a/src/agentic_primitives_gateway/primitives/identity/entra.py
+++ b/src/agentic_primitives_gateway/primitives/identity/entra.py
@@ -76,11 +76,11 @@ class EntraIdentityProvider(SyncRunnerMixin, IdentityProvider):
     def _get_app(self) -> msal.ConfidentialClientApplication:
         """Create an MSAL ConfidentialClientApplication from resolved config."""
         cfg = self._resolve_config()
-        tenant_id = cfg["tenant_id"] or self._tenant_id
+        tenant_id = cfg.get("tenant_id") or self._tenant_id
         authority = f"https://login.microsoftonline.com/{tenant_id}"
         return msal.ConfidentialClientApplication(
-            client_id=cfg["client_id"] or self._client_id,
-            client_credential=cfg["client_secret"] or self._client_secret,
+            client_id=cfg.get("client_id") or self._client_id,
+            client_credential=cfg.get("client_secret") or self._client_secret,
             authority=authority,
         )
 

--- a/src/agentic_primitives_gateway/primitives/identity/keycloak.py
+++ b/src/agentic_primitives_gateway/primitives/identity/keycloak.py
@@ -81,20 +81,20 @@ class KeycloakIdentityProvider(SyncRunnerMixin, IdentityProvider):
         """Create a KeycloakOpenID client from resolved config."""
         cfg = self._resolve_config()
         return KeycloakOpenID(
-            server_url=cfg["server_url"] or self._server_url,
-            realm_name=cfg["realm"] or self._realm,
-            client_id=cfg["client_id"] or self._client_id,
-            client_secret_key=cfg["client_secret"] or self._client_secret,
+            server_url=cfg.get("server_url") or self._server_url,
+            realm_name=cfg.get("realm") or self._realm,
+            client_id=cfg.get("client_id") or self._client_id,
+            client_secret_key=cfg.get("client_secret") or self._client_secret,
         )
 
     def _get_admin(self) -> KeycloakAdmin:
         """Create a KeycloakAdmin client from resolved config."""
         cfg = self._resolve_config()
         return KeycloakAdmin(
-            server_url=cfg["server_url"] or self._server_url,
-            realm_name=cfg["realm"] or self._realm,
-            client_id=cfg["client_id"] or self._client_id,
-            client_secret_key=cfg["client_secret"] or self._client_secret,
+            server_url=cfg.get("server_url") or self._server_url,
+            realm_name=cfg.get("realm") or self._realm,
+            client_id=cfg.get("client_id") or self._client_id,
+            client_secret_key=cfg.get("client_secret") or self._client_secret,
         )
 
     # ── Data plane — runtime token operations ─────────────────────

--- a/src/agentic_primitives_gateway/primitives/identity/okta.py
+++ b/src/agentic_primitives_gateway/primitives/identity/okta.py
@@ -81,7 +81,7 @@ class OktaIdentityProvider(SyncRunnerMixin, IdentityProvider):
 
     def _base_url(self) -> str:
         cfg = self._resolve_config()
-        domain = cfg["domain"] or self._domain
+        domain = cfg.get("domain") or self._domain
         return f"https://{domain}"
 
     def _token_url(self) -> str:
@@ -92,7 +92,7 @@ class OktaIdentityProvider(SyncRunnerMixin, IdentityProvider):
 
     def _admin_headers(self) -> dict[str, str]:
         cfg = self._resolve_config()
-        token = cfg["api_token"] or self._api_token
+        token = cfg.get("api_token") or self._api_token
         if not token:
             raise ValueError(
                 "Okta API token required for admin operations. "
@@ -102,7 +102,10 @@ class OktaIdentityProvider(SyncRunnerMixin, IdentityProvider):
 
     def _client_auth(self) -> tuple[str, str]:
         cfg = self._resolve_config()
-        return (cfg["client_id"] or self._client_id or "", cfg["client_secret"] or self._client_secret or "")
+        return (
+            cfg.get("client_id") or self._client_id or "",
+            cfg.get("client_secret") or self._client_secret or "",
+        )
 
     # ── Data plane — runtime token operations ─────────────────────
 
@@ -147,7 +150,7 @@ class OktaIdentityProvider(SyncRunnerMixin, IdentityProvider):
             state = custom_state or uuid.uuid4().hex
             cfg = self._resolve_config()
             params: dict[str, str] = {
-                "client_id": cfg["client_id"] or self._client_id or "",
+                "client_id": cfg.get("client_id") or self._client_id or "",
                 "response_type": "code",
                 "scope": scope or "openid",
                 "redirect_uri": callback_url or "",

--- a/src/agentic_primitives_gateway/routes/a2a.py
+++ b/src/agentic_primitives_gateway/routes/a2a.py
@@ -34,9 +34,12 @@ from agentic_primitives_gateway.agents.runner import AgentRunner
 from agentic_primitives_gateway.agents.store import AgentStore
 from agentic_primitives_gateway.audit.emit import emit_audit_event
 from agentic_primitives_gateway.audit.models import AuditAction, AuditOutcome, ResourceType
-from agentic_primitives_gateway.auth.access import require_access
+from agentic_primitives_gateway.auth.access import (
+    ProviderOverrideSource,
+    apply_filtered_provider_overrides,
+    require_access,
+)
 from agentic_primitives_gateway.config import settings
-from agentic_primitives_gateway.context import set_provider_overrides
 from agentic_primitives_gateway.models.a2a import (
     A2AAgentCapabilities,
     A2AAgentCard,
@@ -105,8 +108,11 @@ async def _require_agent(name: str) -> AgentSpec:
 
     store = _get_store()
     spec: AgentSpec = await resolve_agent_spec(store, name, require_principal())
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.A2A,
+        resource_id=spec.name,
+    )
     return spec
 
 

--- a/src/agentic_primitives_gateway/routes/agents.py
+++ b/src/agentic_primitives_gateway/routes/agents.py
@@ -15,10 +15,13 @@ from agentic_primitives_gateway.agents.store import AgentStore
 from agentic_primitives_gateway.agents.tools import _TOOL_CATALOG, build_tool_list
 from agentic_primitives_gateway.audit.emit import emit_audit_event
 from agentic_primitives_gateway.audit.models import AuditAction, AuditOutcome, ResourceType
-from agentic_primitives_gateway.auth.access import require_owner_or_admin
+from agentic_primitives_gateway.auth.access import (
+    ProviderOverrideSource,
+    apply_filtered_provider_overrides,
+    require_owner_or_admin,
+)
 from agentic_primitives_gateway.context import (
     get_provider_override,
-    set_provider_overrides,
 )
 from agentic_primitives_gateway.models.agents import (
     AgentLineage,
@@ -271,8 +274,11 @@ async def get_agent_tools(name: str, owner: str | None = None) -> AgentToolsResp
     spec: AgentSpec = await resolve_agent_spec(store, name, require_principal(), owner_query=owner)
 
     # Apply agent-level provider overrides so we resolve the correct providers
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.AGENT_RUN,
+        resource_id=spec.name,
+    )
 
     # Build the tool list (same as the runner does).  Per-primitive
     # context (memory namespace, session IDs, team_run_id) comes from
@@ -318,8 +324,11 @@ async def get_agent_memory(name: str, session_id: str | None = None, owner: str 
     spec: AgentSpec = await resolve_agent_spec(store, name, require_principal(), owner_query=owner)
 
     # Apply agent-level provider overrides so we read from the same provider the agent writes to
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.AGENT_RUN,
+        resource_id=spec.name,
+    )
 
     mem_config = spec.primitives.get("memory")
     if not mem_config or not mem_config.enabled:
@@ -404,8 +413,11 @@ async def chat_with_agent(name: str, request: ChatRequest) -> ChatResponse:
     spec = await resolve_agent_spec(store, name, require_principal())
 
     # Apply agent-level provider overrides to the current request context
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.AGENT_RUN,
+        resource_id=spec.name,
+    )
 
     return await _runner.run(
         spec=spec,
@@ -425,8 +437,11 @@ async def chat_with_agent_stream(name: str, request: ChatRequest) -> StreamingRe
     store = _get_store()
     spec = await resolve_agent_spec(store, name, require_principal())
 
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.AGENT_RUN,
+        resource_id=spec.name,
+    )
 
     session_id = request.session_id or ""
     queue, _ = _bg.start(
@@ -443,8 +458,11 @@ async def list_sessions(name: str) -> dict:
     store = _get_store()
     spec = await resolve_agent_spec(store, name, require_principal())
 
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.AGENT_RUN,
+        resource_id=spec.name,
+    )
 
     actor_id = resolve_actor_id(spec, require_principal())
     sessions: list[dict[str, Any]] = []
@@ -466,8 +484,11 @@ async def cleanup_sessions(name: str, keep: int = 5) -> dict:
     store = _get_store()
     spec = await resolve_agent_spec(store, name, require_principal())
 
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.AGENT_RUN,
+        resource_id=spec.name,
+    )
 
     actor_id = resolve_actor_id(spec, require_principal())
     deleted_count = 0
@@ -493,8 +514,11 @@ async def delete_session(name: str, session_id: str) -> dict:
     store = _get_store()
     spec = await resolve_agent_spec(store, name, require_principal())
 
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.AGENT_RUN,
+        resource_id=spec.name,
+    )
 
     actor_id = resolve_actor_id(spec, require_principal())
     try:
@@ -585,8 +609,11 @@ async def get_session_history(name: str, session_id: str) -> SessionHistoryRespo
     store = _get_store()
     spec = await resolve_agent_spec(store, name, require_principal())
 
-    if spec.provider_overrides:
-        set_provider_overrides(spec.provider_overrides)
+    apply_filtered_provider_overrides(
+        spec.provider_overrides,
+        source=ProviderOverrideSource.AGENT_RUN,
+        resource_id=spec.name,
+    )
 
     actor_id = resolve_actor_id(spec, require_principal())
     messages: list[dict[str, str]] = []

--- a/src/agentic_primitives_gateway/routes/memory.py
+++ b/src/agentic_primitives_gateway/routes/memory.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Response
 
 from agentic_primitives_gateway.audit.emit import audit_mutation
 from agentic_primitives_gateway.audit.models import AuditAction, ResourceType
+from agentic_primitives_gateway.auth.access import require_pool_access, require_pool_delete
 from agentic_primitives_gateway.models.enums import Primitive
 from agentic_primitives_gateway.models.memory import (
     AddStrategyRequest,
@@ -35,14 +36,63 @@ router = APIRouter(
 )
 
 
+_USER_SCOPE_MARKER = ":u:"
+
+
 def _check_actor(actor_id: str) -> None:
     """Validate the caller owns this actor_id."""
     require_user_scoped(actor_id, require_principal())
 
 
 def _check_namespace(namespace: str) -> None:
-    """Validate the caller owns this namespace."""
+    """User-scope check for ``:u:{id}`` namespaces.
+
+    This only covers private per-user namespaces.  Unscoped (shared)
+    namespaces skip this and must be additionally guarded by
+    :func:`_check_pool_access` on each pool route.
+    """
     require_user_scoped(namespace, require_principal())
+
+
+async def _check_pool_access(namespace: str, *, for_delete: bool = False) -> None:
+    """Gate unscoped shared-pool access via transitive-through-agents ACL.
+
+    User-scoped namespaces (``…:u:{id}``) are handled upstream by
+    :func:`_check_namespace` — we only need the transitive check on
+    unscoped names, which is where the REST bypass previously lived.
+    ``for_delete`` switches to the stricter owner-only rule.
+
+    Admins short-circuit *before* we touch the agent/team stores so
+    unit tests that exercise the routes without initializing the
+    stores still pass — the noop auth backend treats tests as admin.
+    Non-admin callers require the stores to be initialized; if they
+    aren't, we fail closed with a 503 rather than let access slip
+    through.
+    """
+    if _USER_SCOPE_MARKER in namespace:
+        return
+    principal = require_principal()
+    if principal.is_admin:
+        return
+    from agentic_primitives_gateway.routes.agents import _get_store as _get_agent_store
+    from agentic_primitives_gateway.routes.teams import _get_store as _get_team_store
+
+    try:
+        agent_store = _get_agent_store()
+        team_store = _get_team_store()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Pool access control unavailable: agent/team stores not initialized",
+        ) from exc
+
+    check = require_pool_delete if for_delete else require_pool_access
+    await check(
+        namespace,
+        principal=principal,
+        agent_store=agent_store,
+        team_store=team_store,
+    )
 
 
 # ── Namespace discovery ──────────────────────────────────────────────
@@ -340,6 +390,7 @@ async def delete_strategy(memory_id: str, strategy_id: str) -> Response:
 @router.post("/{namespace}", response_model=MemoryRecord, status_code=201)
 async def store_memory(namespace: str, request: StoreMemoryRequest) -> MemoryRecord:
     _check_namespace(namespace)
+    await _check_pool_access(namespace)
     async with audit_mutation(
         AuditAction.MEMORY_RECORD_WRITE,
         resource_type=ResourceType.MEMORY,
@@ -356,6 +407,7 @@ async def store_memory(namespace: str, request: StoreMemoryRequest) -> MemoryRec
 @router.get("/{namespace}/{key}", response_model=MemoryRecord)
 async def retrieve_memory(namespace: str, key: str) -> MemoryRecord:
     _check_namespace(namespace)
+    await _check_pool_access(namespace)
     record = await registry.memory.retrieve(namespace=namespace, key=key)
     if record is None:
         raise HTTPException(status_code=404, detail="Memory not found")
@@ -369,6 +421,7 @@ async def list_memories(
     offset: int = Query(default=0, ge=0),
 ) -> ListMemoryResponse:
     _check_namespace(namespace)
+    await _check_pool_access(namespace)
     records = await registry.memory.list_memories(namespace=namespace, limit=limit, offset=offset)
     return ListMemoryResponse(records=records, total=len(records))
 
@@ -376,6 +429,7 @@ async def list_memories(
 @router.post("/{namespace}/search", response_model=SearchMemoryResponse)
 async def search_memories(namespace: str, request: SearchMemoryRequest) -> SearchMemoryResponse:
     _check_namespace(namespace)
+    await _check_pool_access(namespace)
     results = await registry.memory.search(
         namespace=namespace,
         query=request.query,
@@ -388,6 +442,7 @@ async def search_memories(namespace: str, request: SearchMemoryRequest) -> Searc
 @router.delete("/{namespace}/{key}")
 async def delete_memory(namespace: str, key: str) -> Response:
     _check_namespace(namespace)
+    await _check_pool_access(namespace, for_delete=True)
     async with audit_mutation(
         AuditAction.MEMORY_RECORD_DELETE,
         resource_type=ResourceType.MEMORY,

--- a/src/agentic_primitives_gateway/routes/teams.py
+++ b/src/agentic_primitives_gateway/routes/teams.py
@@ -294,9 +294,12 @@ async def list_team_runs(name: str) -> dict:
 
 
 async def _require_run_owner(team_run_id: str) -> None:
-    """Raise 403 if the current principal does not own the run."""
+    """Raise 403 unless the current principal owns the run."""
+    principal = require_principal()
+    if principal.is_admin:
+        return
     owner = await _bg.get_owner_async(team_run_id)
-    if owner and owner != require_principal().id and not require_principal().is_admin:
+    if owner is None or owner != principal.id:
         raise HTTPException(status_code=403, detail="Forbidden")
 
 

--- a/tests/unit/agents/test_runner.py
+++ b/tests/unit/agents/test_runner.py
@@ -483,6 +483,33 @@ class TestTraceHelpers:
 
         mock_reg.observability.ingest_trace.assert_awaited_once()
 
+    async def test_trace_conversation_attributes_to_current_principal(self) -> None:
+        """Runner-originated traces carry the calling principal's ``user_id``.
+
+        Distinct from the REST ingest path, which relays whatever the
+        caller submits.  The runner is the originator of auto-trace
+        hooks, so it provides the attribution the backend expects.
+        """
+        from agentic_primitives_gateway.auth.models import AuthenticatedPrincipal
+        from agentic_primitives_gateway.context import set_authenticated_principal
+
+        set_authenticated_principal(AuthenticatedPrincipal(id="alice", type="user"))
+        runner = AgentRunner()
+        spec = _make_spec()
+        captured: dict[str, object] = {}
+
+        async def _capture(payload: dict[str, object]) -> None:
+            captured.update(payload)
+
+        try:
+            with patch(f"{_RUNNER_MOD}.registry") as mock_reg:
+                mock_reg.observability = AsyncMock()
+                mock_reg.observability.ingest_trace.side_effect = _capture
+                await runner._trace_conversation("trace-1", spec, "sess", "hi", "hello", 1, [])
+            assert captured.get("user_id") == "alice"
+        finally:
+            set_authenticated_principal(None)
+
     async def test_trace_conversation_failure_silent(self) -> None:
         runner = AgentRunner()
         spec = _make_spec()

--- a/tests/unit/audit/test_all_events_wired.py
+++ b/tests/unit/audit/test_all_events_wired.py
@@ -86,6 +86,7 @@ async def test_memory_mutations_emit():
             patch.object(memroute, "registry", mock_registry),
             patch.object(memroute, "_check_actor"),
             patch.object(memroute, "_check_namespace"),
+            patch.object(memroute, "_check_pool_access", new=AsyncMock()),
         ):
             await memroute.create_event(
                 "actor", "sess", CreateEventRequest(messages=[EventMessage(text="hi", role="user")])

--- a/tests/unit/audit/test_redaction.py
+++ b/tests/unit/audit/test_redaction.py
@@ -59,3 +59,86 @@ class TestScrubSecrets:
     def test_leaves_non_secret_text(self):
         out = scrub_secrets("GET /api/v1/memory/my-ns returned 200")
         assert out == "GET /api/v1/memory/my-ns returned 200"
+
+
+class TestCredentialHeaderCoverage:
+    """Sanitization coverage for ``X-Cred-*`` / ``X-AWS-*`` / ``Authorization``.
+
+    These headers are the per-request credential surface — a downstream
+    library error that wraps the raw request must not leak the header
+    value into application logs or audit events.  The dual defense:
+    ``redact_mapping`` handles dict-keyed metadata (audit events);
+    ``scrub_secrets`` handles free-form text (log messages + exception
+    tracebacks).
+    """
+
+    def test_redact_mapping_x_cred_prefix(self):
+        """Any ``x-cred-*`` key is redacted regardless of the specific service."""
+        out = redact_mapping(
+            {
+                "x-cred-keycloak-client-secret": "abc",
+                "x-cred-langfuse-public-key": "pk-live-xyz",
+                "x-cred-new-service-key": "whatever",
+                "user": "alice",
+            }
+        )
+        assert out["x-cred-keycloak-client-secret"] == REDACTED
+        assert out["x-cred-langfuse-public-key"] == REDACTED
+        assert out["x-cred-new-service-key"] == REDACTED
+        assert out["user"] == "alice"
+
+    def test_redact_mapping_x_cred_prefix_mixed_case(self):
+        out = redact_mapping({"X-Cred-Keycloak-Client-Secret": "abc"})
+        assert out["X-Cred-Keycloak-Client-Secret"] == REDACTED
+
+    def test_redact_mapping_x_aws_prefix_redacts_secret_but_not_region(self):
+        """``X-AWS-Region`` is explicitly allowed through — it isn't a secret."""
+        out = redact_mapping(
+            {
+                "x-aws-secret-access-key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "x-aws-session-token": "FQoGZXIvYXdzEJr...",
+                "x-aws-region": "us-east-1",
+            }
+        )
+        assert out["x-aws-secret-access-key"] == REDACTED
+        assert out["x-aws-session-token"] == REDACTED
+        assert out["x-aws-region"] == "us-east-1"
+
+    def test_redact_mapping_extra_keys_still_honored(self):
+        """Per-call ``extra_keys`` composes with the built-in deny-list."""
+        out = redact_mapping({"tenant_secret": "s"}, extra_keys=["tenant_secret"])
+        assert out["tenant_secret"] == REDACTED
+
+    def test_scrub_x_cred_header_line(self):
+        """A traceback-like line carrying ``X-Cred-*: value`` is scrubbed."""
+        line = "httpx.HTTPError: bad creds: X-Cred-Keycloak-Client-Secret: supersecret123"
+        out = scrub_secrets(line)
+        assert "supersecret123" not in out
+        assert REDACTED in out
+
+    def test_scrub_x_cred_header_equals_form(self):
+        """Some libraries format headers as ``key=value``; that shape is covered."""
+        out = scrub_secrets("headers(X-Cred-Langfuse-Public-Key=pk-live-abc)")
+        assert "pk-live-abc" not in out
+
+    def test_scrub_aws_secret_access_key_value(self):
+        """Non-AKIA AWS secret (40-char) in free-form text is scrubbed."""
+        secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        out = scrub_secrets(f"error: X-AWS-Secret-Access-Key: {secret} failed")
+        assert secret not in out
+
+    def test_scrub_aws_session_token_value(self):
+        token = "FQoGZXIvYXdzEJrlongopaquetokenhere"
+        out = scrub_secrets(f"X-AWS-Session-Token: {token}")
+        assert token not in out
+
+    def test_scrub_authorization_non_bearer(self):
+        """Opaque API key in Authorization header (no Bearer prefix) is scrubbed."""
+        out = scrub_secrets("Authorization: my-opaque-api-key-12345")
+        assert "my-opaque-api-key-12345" not in out
+        assert REDACTED in out
+
+    def test_scrub_bearer_authorization_still_works(self):
+        """Bearer path is unchanged — the new pattern doesn't clobber the existing one."""
+        out = scrub_secrets("Authorization: Bearer eyJhbGciOiJI.payload.sig")
+        assert "eyJhbGciOiJI.payload.sig" not in out

--- a/tests/unit/auth/test_access.py
+++ b/tests/unit/auth/test_access.py
@@ -7,10 +7,15 @@ import pytest
 from agentic_primitives_gateway.auth.access import (
     check_access,
     check_owner_or_admin,
+    has_transitive_pool_access,
     require_access,
     require_owner_or_admin,
+    require_pool_access,
+    require_pool_delete,
 )
 from agentic_primitives_gateway.auth.models import ANONYMOUS_PRINCIPAL, AuthenticatedPrincipal
+from agentic_primitives_gateway.models.agents import AgentSpec, PrimitiveConfig
+from agentic_primitives_gateway.models.teams import TeamSpec
 
 
 def _user(
@@ -119,4 +124,173 @@ class TestRequireOwnerOrAdmin:
 
         with pytest.raises(HTTPException) as exc_info:
             require_owner_or_admin(None, "alice")
+        assert exc_info.value.status_code == 403
+
+
+# ── Transitive pool access ───────────────────────────────────────────
+
+
+def _agent(name: str, owner: str, shared_with: list[str], pools: list[str] | None) -> AgentSpec:
+    return AgentSpec(
+        name=name,
+        model="noop/stub",
+        owner_id=owner,
+        shared_with=shared_with,
+        primitives={"memory": PrimitiveConfig(shared_namespaces=pools)},
+    )
+
+
+def _team(name: str, owner: str, shared_with: list[str], shared_memory: str | None) -> TeamSpec:
+    return TeamSpec(
+        name=name,
+        planner="p",
+        synthesizer="s",
+        workers=["w"],
+        owner_id=owner,
+        shared_with=shared_with,
+        shared_memory_namespace=shared_memory,
+    )
+
+
+class _FakeStore:
+    """Minimal async store that mimics ``list_for_user`` ACL semantics."""
+
+    def __init__(self, specs: list) -> None:
+        self._specs = specs
+
+    async def list_for_user(self, principal: AuthenticatedPrincipal) -> list:
+        if principal.is_admin:
+            return list(self._specs)
+        return [
+            s
+            for s in self._specs
+            if s.owner_id == principal.id or "*" in s.shared_with or principal.groups & set(s.shared_with)
+        ]
+
+
+class TestHasTransitivePoolAccess:
+    async def test_admin_always_allowed(self):
+        store = _FakeStore([])
+        admin = _user("root", scopes=frozenset({"admin"}))
+        assert await has_transitive_pool_access(
+            "any-pool", principal=admin, agent_store=store, team_store=_FakeStore([])
+        )
+
+    async def test_owner_of_declaring_agent_allowed(self):
+        agents = _FakeStore([_agent("a", owner="alice", shared_with=[], pools=["shared-p"])])
+        teams = _FakeStore([])
+        assert await has_transitive_pool_access(
+            "shared-p", principal=_user("alice"), agent_store=agents, team_store=teams
+        )
+
+    async def test_sharee_of_declaring_agent_allowed(self):
+        """Bob can reach pool P because he has access to Alice's shared agent."""
+        agents = _FakeStore([_agent("a", owner="alice", shared_with=["*"], pools=["shared-p"])])
+        teams = _FakeStore([])
+        assert await has_transitive_pool_access(
+            "shared-p", principal=_user("bob"), agent_store=agents, team_store=teams
+        )
+
+    async def test_unrelated_pool_denied(self):
+        agents = _FakeStore([_agent("a", owner="alice", shared_with=["*"], pools=["other-p"])])
+        teams = _FakeStore([])
+        assert not await has_transitive_pool_access(
+            "shared-p", principal=_user("bob"), agent_store=agents, team_store=teams
+        )
+
+    async def test_agent_without_memory_primitive_ignored(self):
+        spec = AgentSpec(name="a", model="noop/stub", owner_id="alice", shared_with=["*"])
+        agents = _FakeStore([spec])
+        teams = _FakeStore([])
+        assert not await has_transitive_pool_access(
+            "shared-p", principal=_user("bob"), agent_store=agents, team_store=teams
+        )
+
+    async def test_orphan_pool_is_admin_only(self):
+        """Pool exists in backend but no visible spec declares it → deny."""
+        agents = _FakeStore([])
+        teams = _FakeStore([])
+        assert not await has_transitive_pool_access(
+            "orphan", principal=_user("bob"), agent_store=agents, team_store=teams
+        )
+
+    async def test_team_declaring_pool_allowed(self):
+        agents = _FakeStore([])
+        teams = _FakeStore([_team("t", owner="alice", shared_with=["*"], shared_memory="team-p")])
+        assert await has_transitive_pool_access("team-p", principal=_user("bob"), agent_store=agents, team_store=teams)
+
+    async def test_team_without_matching_pool_denied(self):
+        agents = _FakeStore([])
+        teams = _FakeStore([_team("t", owner="alice", shared_with=["*"], shared_memory="other")])
+        assert not await has_transitive_pool_access(
+            "team-p", principal=_user("bob"), agent_store=agents, team_store=teams
+        )
+
+    async def test_agent_not_visible_to_user_ignored(self):
+        """Private agent of another user does not grant transitive access."""
+        agents = _FakeStore([_agent("a", owner="alice", shared_with=[], pools=["private-p"])])
+        teams = _FakeStore([])
+        assert not await has_transitive_pool_access(
+            "private-p", principal=_user("bob"), agent_store=agents, team_store=teams
+        )
+
+
+class TestRequirePoolAccess:
+    async def test_raises_when_not_transitive(self):
+        from fastapi import HTTPException
+
+        agents = _FakeStore([])
+        teams = _FakeStore([])
+        with pytest.raises(HTTPException) as exc_info:
+            await require_pool_access("p", principal=_user("bob"), agent_store=agents, team_store=teams)
+        assert exc_info.value.status_code == 403
+
+    async def test_returns_none_when_allowed(self):
+        agents = _FakeStore([_agent("a", owner="bob", shared_with=[], pools=["p"])])
+        teams = _FakeStore([])
+        # should not raise
+        await require_pool_access("p", principal=_user("bob"), agent_store=agents, team_store=teams)
+
+
+class TestRequirePoolDelete:
+    """Delete is stricter than access: the caller must OWN a declaring spec.
+
+    Sharing an agent grants read/write on its pool, but dropping a key
+    from the pool is a destructive op reserved to the agent's owner or
+    admin — otherwise a sharee could wipe the owner's data.
+    """
+
+    async def test_admin_allowed(self):
+        agents = _FakeStore([])
+        teams = _FakeStore([])
+        admin = _user("root", scopes=frozenset({"admin"}))
+        await require_pool_delete("p", principal=admin, agent_store=agents, team_store=teams)
+
+    async def test_owner_of_declaring_agent_allowed(self):
+        agents = _FakeStore([_agent("a", owner="alice", shared_with=[], pools=["p"])])
+        teams = _FakeStore([])
+        await require_pool_delete("p", principal=_user("alice"), agent_store=agents, team_store=teams)
+
+    async def test_sharee_of_declaring_agent_denied(self):
+        """Bob has read/write via sharing but cannot delete."""
+        from fastapi import HTTPException
+
+        agents = _FakeStore([_agent("a", owner="alice", shared_with=["*"], pools=["p"])])
+        teams = _FakeStore([])
+        with pytest.raises(HTTPException) as exc_info:
+            await require_pool_delete("p", principal=_user("bob"), agent_store=agents, team_store=teams)
+        assert exc_info.value.status_code == 403
+
+    async def test_owner_of_team_allowed(self):
+        agents = _FakeStore([])
+        teams = _FakeStore([_team("t", owner="alice", shared_with=[], shared_memory="p")])
+        await require_pool_delete("p", principal=_user("alice"), agent_store=agents, team_store=teams)
+
+    async def test_team_sharee_denied(self):
+        from fastapi import HTTPException
+
+        agents = _FakeStore([])
+        teams = _FakeStore([_team("t", owner="alice", shared_with=["*"], shared_memory="p")])
+        with pytest.raises(HTTPException) as exc_info:
+            await require_pool_delete("p", principal=_user("bob"), agent_store=agents, team_store=teams)
         assert exc_info.value.status_code == 403

--- a/tests/unit/core/test_provider_overrides.py
+++ b/tests/unit/core/test_provider_overrides.py
@@ -77,3 +77,67 @@ class TestRestoreOverrides:
         assert get_provider_override("memory") is None
         # Clean up
         set_provider_overrides({})
+
+
+class TestApplyOverridesFiltersTrustSensitive:
+    """Sub-agent delegation must not admit trust-sensitive overrides from a spec."""
+
+    def test_identity_override_in_spec_is_filtered(self) -> None:
+        set_provider_overrides({})
+        spec = AgentSpec(
+            name="child",
+            model="test-model",
+            provider_overrides={
+                "memory": "mem0",
+                "identity": "noop-shadow",
+                "policy": "noop",
+            },
+        )
+        AgentRunner._apply_overrides(spec)
+        # Allow-listed key survived.
+        assert get_provider_override("memory") == "mem0"
+        # Trust-sensitive keys were dropped before reaching the contextvar.
+        assert get_provider_override("identity") is None
+        assert get_provider_override("policy") is None
+        set_provider_overrides({})
+
+    def test_parent_allowlisted_overrides_are_preserved_after_filter(self) -> None:
+        """Merging parent + filtered spec must not wipe parent's prior overrides."""
+        set_provider_overrides({"llm": "bedrock"})
+        spec = AgentSpec(
+            name="child",
+            model="test-model",
+            # Entirely trust-sensitive — nothing from the spec survives the filter.
+            provider_overrides={"identity": "noop-shadow"},
+        )
+        AgentRunner._apply_overrides(spec)
+        # Parent's llm override is still in effect because the merged
+        # dict included it and ``llm`` is on the allow-list.
+        assert get_provider_override("llm") == "bedrock"
+        set_provider_overrides({})
+
+    def test_trust_sensitive_key_in_parent_is_also_filtered(self) -> None:
+        """The delegation filter strips trust-sensitive keys regardless of
+        which layer they came from.
+
+        The auth middleware already strips ``identity`` / ``policy`` at
+        the request boundary, but if one somehow reached the contextvar
+        through another path, the delegation filter catches it again.
+        A parent contextvar with ``identity`` present is stripped when
+        a sub-agent's spec is applied — the filter runs on the merged
+        dict, not only on the spec's contribution.
+        """
+        set_provider_overrides({"identity": "leaked-from-somewhere", "llm": "bedrock"})
+        spec = AgentSpec(
+            name="child",
+            model="test-model",
+            provider_overrides={"memory": "mem0"},
+        )
+        AgentRunner._apply_overrides(spec)
+        # Spec's allow-listed key applied.
+        assert get_provider_override("memory") == "mem0"
+        # Parent's allow-listed key preserved.
+        assert get_provider_override("llm") == "bedrock"
+        # Parent's trust-sensitive key was stripped by the filter too.
+        assert get_provider_override("identity") is None
+        set_provider_overrides({})

--- a/tests/unit/core/test_server_credentials_telemetry.py
+++ b/tests/unit/core/test_server_credentials_telemetry.py
@@ -186,12 +186,23 @@ class TestServerCredentialsUsedEvent:
         assert matching == []
 
     async def test_service_credentials_fallback_emits(self) -> None:
+        """``fallback`` + any server-filled key → emit once.
+
+        ``_emit_server_credentials_used`` is called from the helper
+        when ``defaults`` contains truthy values the caller didn't
+        supply — that's the "operator credentials actually fill gaps
+        in the caller's request" state we want auditable.  If the
+        defaults are all-None there are literally no operator values
+        to fill with; no emit.
+        """
         set_service_credentials({})
         set_authenticated_principal(_non_admin())
         try:
             events = await _collect(
                 ServerCredentialMode.FALLBACK,
-                lambda: get_service_credentials_or_defaults("langfuse", {"public_key": None, "secret_key": None}),
+                lambda: get_service_credentials_or_defaults(
+                    "langfuse", {"public_key": "server-pk", "secret_key": "server-sk"}
+                ),
             )
         finally:
             set_authenticated_principal(None)

--- a/tests/unit/core/test_server_credentials_telemetry.py
+++ b/tests/unit/core/test_server_credentials_telemetry.py
@@ -1,0 +1,224 @@
+"""Tests for degraded-mode surfacing on server-credential fallback.
+
+Covers the two non-blocking observability fixes that ship alongside the
+authz tenet:
+
+1. **Startup warning** in ``main._warn_server_credentials_with_real_auth``
+   when the deployment combines multi-user auth with shared gateway
+   credentials.  Operators see the warning in their boot logs; it's not
+   an error, just "verify this matches your intent."
+2. **Runtime audit event** ``provider.server_credentials_used`` emitted
+   from ``context._emit_server_credentials_used`` whenever the gateway
+   attaches its own ambient credentials on behalf of a non-admin caller
+   (under ``allow_server_credentials: fallback`` / ``always``).  Admin
+   callers are excluded — ambient creds in an admin flow is expected.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from agentic_primitives_gateway.audit.models import AuditAction
+from agentic_primitives_gateway.auth.models import AuthenticatedPrincipal
+from agentic_primitives_gateway.config import settings
+from agentic_primitives_gateway.context import (
+    AWSCredentials,
+    get_boto3_session,
+    get_service_credentials_or_defaults,
+    set_authenticated_principal,
+    set_aws_credentials,
+    set_service_credentials,
+)
+from agentic_primitives_gateway.main import _warn_server_credentials_with_real_auth
+from agentic_primitives_gateway.models.enums import ServerCredentialMode
+
+# ── Startup warning ──────────────────────────────────────────────────
+
+
+class TestStartupWarning:
+    def _with_auth_backend(self, backend: str):
+        prev = settings.auth.backend
+        settings.auth.backend = backend
+        return prev
+
+    def _with_cred_mode(self, mode):
+        prev = settings.allow_server_credentials
+        settings.allow_server_credentials = mode
+        return prev
+
+    def test_no_warning_under_noop_auth(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Noop auth is single-user dev mode — shared creds are expected."""
+        prev_auth = self._with_auth_backend("noop")
+        prev_mode = self._with_cred_mode(ServerCredentialMode.ALWAYS)
+        try:
+            with caplog.at_level(logging.WARNING, logger="agentic_primitives_gateway.main"):
+                _warn_server_credentials_with_real_auth()
+            assert "Server-credential warning" not in caplog.text
+        finally:
+            settings.auth.backend = prev_auth
+            settings.allow_server_credentials = prev_mode
+
+    def test_no_warning_under_never(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Never + real auth is the safer default — no ambient creds ever fire."""
+        prev_auth = self._with_auth_backend("jwt")
+        prev_mode = self._with_cred_mode(ServerCredentialMode.NEVER)
+        try:
+            with caplog.at_level(logging.WARNING, logger="agentic_primitives_gateway.main"):
+                _warn_server_credentials_with_real_auth()
+            assert "Server-credential warning" not in caplog.text
+        finally:
+            settings.auth.backend = prev_auth
+            settings.allow_server_credentials = prev_mode
+
+    def test_warns_on_jwt_plus_fallback(self, caplog: pytest.LogCaptureFixture) -> None:
+        prev_auth = self._with_auth_backend("jwt")
+        prev_mode = self._with_cred_mode(ServerCredentialMode.FALLBACK)
+        try:
+            with caplog.at_level(logging.WARNING, logger="agentic_primitives_gateway.main"):
+                _warn_server_credentials_with_real_auth()
+            assert "Server-credential warning" in caplog.text
+            assert "jwt" in caplog.text
+            assert "fallback" in caplog.text
+        finally:
+            settings.auth.backend = prev_auth
+            settings.allow_server_credentials = prev_mode
+
+    def test_warns_on_api_key_plus_always(self, caplog: pytest.LogCaptureFixture) -> None:
+        prev_auth = self._with_auth_backend("api_key")
+        prev_mode = self._with_cred_mode(ServerCredentialMode.ALWAYS)
+        try:
+            with caplog.at_level(logging.WARNING, logger="agentic_primitives_gateway.main"):
+                _warn_server_credentials_with_real_auth()
+            assert "Server-credential warning" in caplog.text
+            assert "api_key" in caplog.text
+            assert "always" in caplog.text
+        finally:
+            settings.auth.backend = prev_auth
+            settings.allow_server_credentials = prev_mode
+
+
+# ── Runtime audit event ──────────────────────────────────────────────
+
+
+class _CollectorSink:
+    """Minimal AuditSink that records emitted events into a list."""
+
+    def __init__(self) -> None:
+        self.name = "collector"
+        self.events: list = []
+
+    async def emit(self, event) -> None:
+        self.events.append(event)
+
+
+async def _collect(mode: ServerCredentialMode, setup):
+    """Fire a boto3/service-cred resolution under ``mode`` and return emitted events.
+
+    ``setup`` runs with the router wired in; it is expected to trigger
+    the ambient-cred path via ``get_boto3_session`` or
+    ``get_service_credentials_or_defaults``.
+    """
+    from agentic_primitives_gateway.audit.emit import set_audit_router
+    from agentic_primitives_gateway.audit.router import AuditRouter
+
+    sink = _CollectorSink()
+    router = AuditRouter([sink])
+    await router.start()
+    set_audit_router(router)
+    prev_mode = settings.allow_server_credentials
+    settings.allow_server_credentials = mode
+    try:
+        setup()
+    finally:
+        import asyncio
+
+        await asyncio.sleep(0.02)
+        await router.shutdown(timeout=1.0)
+        set_audit_router(None)
+        settings.allow_server_credentials = prev_mode
+    return sink.events
+
+
+def _non_admin() -> AuthenticatedPrincipal:
+    return AuthenticatedPrincipal(id="alice", type="user", scopes=frozenset())
+
+
+def _admin() -> AuthenticatedPrincipal:
+    return AuthenticatedPrincipal(id="root", type="user", scopes=frozenset({"admin"}))
+
+
+class TestServerCredentialsUsedEvent:
+    """The event should fire for non-admin callers whenever the gateway
+    falls back to its own credentials.  Admins don't trip it — their use
+    of ambient creds is the documented operator path.
+    """
+
+    async def test_boto3_fallback_emits_for_non_admin(self) -> None:
+        set_aws_credentials(None)
+        set_authenticated_principal(_non_admin())
+        try:
+            events = await _collect(
+                ServerCredentialMode.ALWAYS,
+                lambda: get_boto3_session(default_region="us-east-1"),
+            )
+        finally:
+            set_authenticated_principal(None)
+
+        matching = [e for e in events if e.action == AuditAction.PROVIDER_SERVER_CREDENTIALS_USED]
+        assert len(matching) == 1
+        assert matching[0].metadata["service"] == "aws"
+        assert matching[0].metadata["mode"] == "always"
+
+    async def test_boto3_fallback_silent_for_admin(self) -> None:
+        set_aws_credentials(None)
+        set_authenticated_principal(_admin())
+        try:
+            events = await _collect(
+                ServerCredentialMode.ALWAYS,
+                lambda: get_boto3_session(default_region="us-east-1"),
+            )
+        finally:
+            set_authenticated_principal(None)
+
+        matching = [e for e in events if e.action == AuditAction.PROVIDER_SERVER_CREDENTIALS_USED]
+        assert matching == []
+
+    async def test_service_credentials_fallback_emits(self) -> None:
+        set_service_credentials({})
+        set_authenticated_principal(_non_admin())
+        try:
+            events = await _collect(
+                ServerCredentialMode.FALLBACK,
+                lambda: get_service_credentials_or_defaults("langfuse", {"public_key": None, "secret_key": None}),
+            )
+        finally:
+            set_authenticated_principal(None)
+
+        matching = [e for e in events if e.action == AuditAction.PROVIDER_SERVER_CREDENTIALS_USED]
+        assert len(matching) == 1
+        assert matching[0].metadata["service"] == "langfuse"
+        assert matching[0].metadata["mode"] == "fallback"
+
+    async def test_caller_creds_present_no_event(self) -> None:
+        """Ambient-cred path isn't taken when the caller presents their own."""
+        set_aws_credentials(
+            AWSCredentials(
+                access_key_id="AKIAIOSFODNN7EXAMPLE",
+                secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                region="us-west-2",
+            )
+        )
+        set_authenticated_principal(_non_admin())
+        try:
+            events = await _collect(
+                ServerCredentialMode.ALWAYS,
+                lambda: get_boto3_session(default_region="us-east-1"),
+            )
+        finally:
+            set_aws_credentials(None)
+            set_authenticated_principal(None)
+
+        matching = [e for e in events if e.action == AuditAction.PROVIDER_SERVER_CREDENTIALS_USED]
+        assert matching == []

--- a/tests/unit/primitives/memory/test_context_branches.py
+++ b/tests/unit/primitives/memory/test_context_branches.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agentic_primitives_gateway.config import settings
 from agentic_primitives_gateway.context import (
     AWSCredentials,
     get_boto3_session,
@@ -12,71 +13,169 @@ from agentic_primitives_gateway.context import (
     set_aws_credentials,
     set_service_credentials,
 )
+from agentic_primitives_gateway.models.enums import ServerCredentialMode
+
+
+class _ModeOverride:
+    """Context manager that swaps ``allow_server_credentials`` for a test."""
+
+    def __init__(self, mode: ServerCredentialMode) -> None:
+        self._mode = mode
+        self._prev: object = None
+
+    def __enter__(self):
+        self._prev = settings.allow_server_credentials
+        settings.allow_server_credentials = self._mode
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        settings.allow_server_credentials = self._prev
 
 
 class TestGetServiceCredentialsOrDefaults:
-    """Test all branches of get_service_credentials_or_defaults()."""
+    """Three-branch rule — mode determines the entire behavior.
 
-    def test_client_creds_override_defaults(self):
-        set_service_credentials({"langfuse": {"public_key": "client-pk", "secret_key": "client-sk"}})
-        result = get_service_credentials_or_defaults(
-            "langfuse",
-            {"public_key": "server-pk", "secret_key": "server-sk", "base_url": "https://server.com"},
-        )
-        assert result["public_key"] == "client-pk"
-        assert result["secret_key"] == "client-sk"
-        assert result["base_url"] == "https://server.com"
+    ``NEVER``: caller supplies the full shape; ``defaults`` values are
+    not consulted.  ``ALWAYS``: caller is ignored; ``defaults`` is
+    returned unchanged.  ``FALLBACK``: merge (caller wins), emit
+    ``provider.server_credentials_used`` once if any key was filled
+    from ``defaults``.
+    """
 
-    def test_no_client_creds_server_fallback_allowed(self):
-        set_service_credentials({})
-        with patch("agentic_primitives_gateway.context._server_credentials_allowed", return_value=True):
-            result = get_service_credentials_or_defaults(
-                "langfuse",
-                {"public_key": "server-pk", "secret_key": None},
-            )
-        assert result["public_key"] == "server-pk"
+    # ── NEVER ────────────────────────────────────────────────────
 
-    def test_no_client_creds_server_fallback_disabled_with_defaults(self):
+    def test_never_empty_client_creds_raises(self):
         set_service_credentials({})
         with (
-            patch("agentic_primitives_gateway.context._server_credentials_allowed", return_value=False),
-            pytest.raises(ValueError, match="credential fallback is disabled"),
+            _ModeOverride(ServerCredentialMode.NEVER),
+            pytest.raises(ValueError, match="No langfuse credentials provided"),
         ):
             get_service_credentials_or_defaults(
                 "langfuse",
                 {"public_key": "server-pk", "secret_key": "server-sk"},
             )
 
-    def test_no_client_creds_no_server_fallback_no_defaults_returns_merged(self):
-        set_service_credentials({})
-        with patch("agentic_primitives_gateway.context._server_credentials_allowed", return_value=False):
-            # defaults have no truthy values, so no error raised
+    def test_never_full_client_creds_returns_them_without_defaults(self):
+        """Even when operator defaults exist, ``never`` ignores them."""
+        set_service_credentials({"langfuse": {"public_key": "alice-pk", "secret_key": "alice-sk"}})
+        with _ModeOverride(ServerCredentialMode.NEVER):
             result = get_service_credentials_or_defaults(
                 "langfuse",
-                {"public_key": None, "secret_key": None},
+                {"public_key": "server-pk", "secret_key": "server-sk", "host": "https://server.com"},
             )
-        assert result["public_key"] is None
+        assert result["public_key"] == "alice-pk"
+        assert result["secret_key"] == "alice-sk"
+        # ``host`` wasn't vended by Alice and under NEVER defaults don't fill.
+        assert result["host"] is None
+
+    def test_never_partial_client_creds_returns_shape_preserving_dict(self):
+        """Partial client creds → shape-preserving dict with ``None`` for missing keys."""
+        set_service_credentials({"langfuse": {"public_key": "alice-pk"}})
+        with _ModeOverride(ServerCredentialMode.NEVER):
+            result = get_service_credentials_or_defaults(
+                "langfuse",
+                {"public_key": "server-pk", "secret_key": "server-sk"},
+            )
+        assert result["public_key"] == "alice-pk"
         assert result["secret_key"] is None
 
-    def test_client_creds_merge_with_defaults(self):
-        set_service_credentials({"svc": {"key_a": "from_client"}})
-        result = get_service_credentials_or_defaults(
-            "svc",
-            {"key_a": "default_a", "key_b": "default_b"},
-        )
-        assert result["key_a"] == "from_client"
+    # ── ALWAYS ───────────────────────────────────────────────────
+
+    def test_always_ignores_client_creds(self):
+        """Under ``always``, operator controls credentials — caller values discarded."""
+        set_service_credentials({"langfuse": {"public_key": "alice-pk", "secret_key": "alice-sk"}})
+        with _ModeOverride(ServerCredentialMode.ALWAYS):
+            result = get_service_credentials_or_defaults(
+                "langfuse",
+                {"public_key": "server-pk", "secret_key": "server-sk"},
+            )
+        assert result["public_key"] == "server-pk"
+        assert result["secret_key"] == "server-sk"
+
+    def test_always_empty_client_creds_returns_defaults(self):
+        set_service_credentials({})
+        with _ModeOverride(ServerCredentialMode.ALWAYS):
+            result = get_service_credentials_or_defaults(
+                "langfuse",
+                {"public_key": "server-pk", "secret_key": "server-sk"},
+            )
+        assert result == {"public_key": "server-pk", "secret_key": "server-sk"}
+
+    # ── FALLBACK ─────────────────────────────────────────────────
+
+    def test_fallback_merges_client_wins(self):
+        set_service_credentials({"svc": {"key_a": "alice"}})
+        with _ModeOverride(ServerCredentialMode.FALLBACK):
+            result = get_service_credentials_or_defaults(
+                "svc",
+                {"key_a": "default_a", "key_b": "default_b"},
+            )
+        assert result["key_a"] == "alice"
         assert result["key_b"] == "default_b"
 
-    def test_empty_client_cred_values_not_merged(self):
-        """Client creds with empty string values should not override defaults."""
+    def test_fallback_empty_client_creds_uses_defaults(self):
+        set_service_credentials({})
+        with _ModeOverride(ServerCredentialMode.FALLBACK):
+            result = get_service_credentials_or_defaults(
+                "langfuse",
+                {"public_key": "server-pk", "secret_key": None},
+            )
+        assert result["public_key"] == "server-pk"
+
+    def test_fallback_empty_values_dont_override(self):
+        """Empty-string client values are ignored — a fall-through to defaults."""
         set_service_credentials({"svc": {"key_a": ""}})
-        result = get_service_credentials_or_defaults(
-            "svc",
-            {"key_a": "default_a"},
-        )
-        # client_creds is truthy (dict has entries), so it proceeds as client creds
-        # but empty values aren't merged, so default stays
+        with _ModeOverride(ServerCredentialMode.FALLBACK):
+            result = get_service_credentials_or_defaults(
+                "svc",
+                {"key_a": "default_a"},
+            )
         assert result["key_a"] == "default_a"
+
+    def test_fallback_full_override_no_audit_emit(self):
+        """No server-filled keys → no audit event."""
+        set_service_credentials({"svc": {"key_a": "alice", "key_b": "alice"}})
+        with (
+            _ModeOverride(ServerCredentialMode.FALLBACK),
+            patch("agentic_primitives_gateway.context._emit_server_credentials_used") as emit,
+        ):
+            get_service_credentials_or_defaults(
+                "svc",
+                {"key_a": "default_a", "key_b": "default_b"},
+            )
+        emit.assert_not_called()
+
+    def test_fallback_partial_override_emits_once(self):
+        """Any server-filled key → emit exactly once (not per key)."""
+        set_service_credentials({"svc": {"key_a": "alice"}})
+        with (
+            _ModeOverride(ServerCredentialMode.FALLBACK),
+            patch("agentic_primitives_gateway.context._emit_server_credentials_used") as emit,
+        ):
+            get_service_credentials_or_defaults(
+                "svc",
+                {"key_a": "default_a", "key_b": "default_b", "key_c": "default_c"},
+            )
+        emit.assert_called_once_with("svc")
+
+    def test_fallback_emit_for_empty_client_creds(self):
+        set_service_credentials({})
+        with (
+            _ModeOverride(ServerCredentialMode.FALLBACK),
+            patch("agentic_primitives_gateway.context._emit_server_credentials_used") as emit,
+        ):
+            get_service_credentials_or_defaults("svc", {"key_a": "default_a"})
+        emit.assert_called_once_with("svc")
+
+    def test_always_emits_for_non_empty_defaults(self):
+        """``always`` is also a "shared-cred" state — audit consumers want to see it."""
+        set_service_credentials({})
+        with (
+            _ModeOverride(ServerCredentialMode.ALWAYS),
+            patch("agentic_primitives_gateway.context._emit_server_credentials_used") as emit,
+        ):
+            get_service_credentials_or_defaults("svc", {"key_a": "default_a"})
+        emit.assert_called_once_with("svc")
 
 
 class TestGetBoto3Session:

--- a/tests/unit/routes/test_auth_gating.py
+++ b/tests/unit/routes/test_auth_gating.py
@@ -443,6 +443,191 @@ class TestIdentityAdminGating:
 # ── Observability: cross-user query restriction ──────────────────────
 
 
+# ── X-Provider-* override: admin-only ───────────────────────────────
+
+
+class TestProviderOverrideAllowlist:
+    """``X-Provider-*`` overrides are filtered against a universal allow-list.
+
+    The allow-list applies to every caller regardless of scope.  Admins
+    have no legitimate runtime reason to flip identity or policy
+    backends (those are operator decisions done at startup or in
+    shadow deployments), and the invariant "trust-sensitive primitives
+    cannot be overridden at request time" is easier to reason about
+    when it's universal.
+
+    The allow-list also applies to ``spec.provider_overrides`` on
+    agent specs — otherwise a non-admin agent owner could re-inject
+    a stripped override via the spec field.
+    """
+
+    def _with_backend(self, principal):
+        from agentic_primitives_gateway.auth.base import AuthBackend
+
+        class FixedBackend(AuthBackend):
+            async def authenticate(self, request):
+                return principal
+
+        prev = getattr(app.state, "auth_backend", None)
+        app.state.auth_backend = FixedBackend()
+        return prev
+
+    def _install_no_relay_identity_backend(self):
+        from agentic_primitives_gateway.models.enums import Primitive
+        from agentic_primitives_gateway.primitives.identity.noop import NoopIdentityProvider
+        from agentic_primitives_gateway.registry import registry
+
+        class _NoRelayStub(NoopIdentityProvider):
+            async def supports_user_relay(self) -> bool:
+                return False
+
+        prim = registry.get_primitive(Primitive.IDENTITY)
+        prev = prim.get()
+        prim._providers[prim.default_name] = _NoRelayStub()  # type: ignore[assignment]
+        return prim, prev
+
+    def _install_shadow_relay_backend(self, prim) -> None:
+        """Register a second identity backend that always relays."""
+        from agentic_primitives_gateway.primitives.identity.noop import NoopIdentityProvider
+
+        class _AlwaysRelay(NoopIdentityProvider):
+            async def supports_user_relay(self) -> bool:
+                return True
+
+        prim._providers["noop-shadow"] = _AlwaysRelay()  # type: ignore[assignment]
+
+    def test_admin_also_cannot_override_identity_backend(self) -> None:
+        """Admin has no bypass — the allow-list is universal."""
+        prev_backend = self._with_backend(_admin())
+        prim, prev_provider = self._install_no_relay_identity_backend()
+        self._install_shadow_relay_backend(prim)
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            resp = c.post(
+                "/api/v1/identity/token",
+                json={"credential_provider": "test", "workload_token": "tok"},
+                headers={"X-Provider-Identity": "noop-shadow"},
+            )
+            assert resp.status_code == 200
+        finally:
+            prim._providers.pop("noop-shadow", None)
+            prim._providers[prim.default_name] = prev_provider  # type: ignore[assignment]
+            app.state.auth_backend = prev_backend
+
+    def test_memory_override_is_preserved_for_any_caller(self) -> None:
+        """Non-trust-sensitive overrides are honoured regardless of scope."""
+        from agentic_primitives_gateway.context import get_provider_override
+
+        captured: dict[str, str | None] = {}
+
+        @app.get("/__test_override_probe__")
+        async def probe():
+            captured["memory"] = get_provider_override("memory")
+            captured["identity"] = get_provider_override("identity")
+            return {"ok": True}
+
+        prev_backend = self._with_backend(_user("alice"))
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            c.get(
+                "/__test_override_probe__",
+                headers={
+                    "X-Provider-Memory": "some-memory-backend",
+                    "X-Provider-Identity": "noop-shadow",
+                },
+            )
+            # Memory override survives — routing preference.
+            assert captured["memory"] == "some-memory-backend"
+            # Identity override is stripped.
+            assert captured["identity"] is None
+        finally:
+            app.state.auth_backend = prev_backend
+            app.router.routes = [r for r in app.router.routes if getattr(r, "path", None) != "/__test_override_probe__"]
+
+    def test_admin_memory_override_is_also_preserved(self) -> None:
+        from agentic_primitives_gateway.context import get_provider_override
+
+        captured: dict[str, str | None] = {}
+
+        @app.get("/__test_admin_override_probe__")
+        async def probe():
+            captured["memory"] = get_provider_override("memory")
+            captured["identity"] = get_provider_override("identity")
+            captured["policy"] = get_provider_override("policy")
+            return {"ok": True}
+
+        prev_backend = self._with_backend(_admin())
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            c.get(
+                "/__test_admin_override_probe__",
+                headers={
+                    "X-Provider-Memory": "some-memory-backend",
+                    "X-Provider-Identity": "noop-shadow",
+                    "X-Provider-Policy": "noop",
+                },
+            )
+            assert captured["memory"] == "some-memory-backend"
+            assert captured["identity"] is None
+            assert captured["policy"] is None
+        finally:
+            app.state.auth_backend = prev_backend
+            app.router.routes = [
+                r for r in app.router.routes if getattr(r, "path", None) != "/__test_admin_override_probe__"
+            ]
+
+    def test_default_provider_override_is_stripped(self) -> None:
+        from agentic_primitives_gateway.context import get_provider_override
+
+        captured: dict[str, str | None] = {}
+
+        @app.get("/__test_default_override_probe__")
+        async def probe():
+            captured["identity"] = get_provider_override("identity")
+            captured["memory"] = get_provider_override("memory")
+            return {"ok": True}
+
+        prev_backend = self._with_backend(_user("alice"))
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            c.get(
+                "/__test_default_override_probe__",
+                headers={"X-Provider": "some-default-backend"},
+            )
+            # Default stripped → neither primitive sees an override.
+            assert captured["identity"] is None
+            assert captured["memory"] is None
+        finally:
+            app.state.auth_backend = prev_backend
+            app.router.routes = [
+                r for r in app.router.routes if getattr(r, "path", None) != "/__test_default_override_probe__"
+            ]
+
+    def test_spec_provider_overrides_are_also_filtered(self) -> None:
+        from agentic_primitives_gateway.auth.access import (
+            ProviderOverrideSource,
+            apply_filtered_provider_overrides,
+        )
+        from agentic_primitives_gateway.context import get_provider_override, set_provider_overrides
+
+        set_provider_overrides({})
+        apply_filtered_provider_overrides(
+            {
+                "memory": "some-mem-backend",
+                "identity": "noop-shadow",
+                "policy": "noop",
+            },
+            source=ProviderOverrideSource.TEST,
+            resource_id="agent-x",
+        )
+        assert get_provider_override("memory") == "some-mem-backend"
+        assert get_provider_override("identity") is None
+        assert get_provider_override("policy") is None
+
+
+# ── Observability: cross-user query restriction ──────────────────────
+
+
 class TestObservabilityCrossUserQuery:
     """Observability list_sessions restricts user_id for non-admins."""
 

--- a/tests/unit/routes/test_auth_gating.py
+++ b/tests/unit/routes/test_auth_gating.py
@@ -535,3 +535,129 @@ class TestCodeInterpreterListSessionsFiltering:
             assert "bob-ci" not in session_ids
         finally:
             app.state.auth_backend = prev
+
+
+# ── Memory pools: transitive-through-agents ACL ──────────────────────
+
+
+class TestMemoryPoolTransitiveACL:
+    """Unscoped shared-pool endpoints require transitive access.
+
+    The gateway enforces pool-level access by walking specs visible
+    to the caller: if some agent or team the caller can access declares
+    the pool, the caller gets read/write REST parity with what they could
+    already do via the agent-tool surface.  Delete is stricter.
+    """
+
+    def _stores(self, tmp_path):
+        """Wire real stores into the module-level slots used by routes."""
+        from agentic_primitives_gateway.agents.file_store import FileAgentStore, FileTeamStore
+        from agentic_primitives_gateway.routes.agents import set_agent_store
+        from agentic_primitives_gateway.routes.teams import set_team_store
+
+        agent_store = FileAgentStore(path=str(tmp_path / "agents.json"))
+        team_store = FileTeamStore(path=str(tmp_path / "teams.json"))
+        team_store.bind_agent_store(agent_store)
+        set_agent_store(agent_store)
+        set_team_store(team_store)
+        return agent_store, team_store
+
+    def _fixed_backend(self, principal):
+        from agentic_primitives_gateway.auth.base import AuthBackend
+
+        class FixedBackend(AuthBackend):
+            async def authenticate(self, request):
+                return principal
+
+        prev = getattr(app.state, "auth_backend", None)
+        app.state.auth_backend = FixedBackend()
+        return prev
+
+    def _create_agent(self, client, owner_id: str, pool: str, shared_with=None):
+        """POST a spec that declares ``pool`` in shared_namespaces."""
+        payload = {
+            "name": f"agent-{owner_id}",
+            "model": "noop/stub",
+            "primitives": {"memory": {"shared_namespaces": [pool]}},
+            "shared_with": shared_with or [],
+        }
+        # owner_id flows from the authenticated principal; caller injects
+        # the right backend before invoking this helper.
+        resp = client.post("/api/v1/agents", json=payload)
+        assert resp.status_code == 201, resp.text
+        return resp.json()
+
+    def test_bob_without_any_declaring_agent_denied(self, tmp_path) -> None:
+        """Orphan-pool case: bob has no agent that declares pool-p."""
+        self._stores(tmp_path)
+        prev = self._fixed_backend(_user("bob"))
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            resp = c.post("/api/v1/memory/pool-p", json={"key": "k1", "content": "v"})
+            assert resp.status_code == 403
+        finally:
+            app.state.auth_backend = prev
+
+    def test_bob_owns_agent_declaring_pool_allowed_read_write(self, tmp_path) -> None:
+        self._stores(tmp_path)
+        prev = self._fixed_backend(_user("bob"))
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            self._create_agent(c, owner_id="bob", pool="pool-p")
+            assert c.post("/api/v1/memory/pool-p", json={"key": "k", "content": "v"}).status_code == 201
+            assert c.get("/api/v1/memory/pool-p/k").status_code == 200
+            assert c.get("/api/v1/memory/pool-p").status_code == 200
+            assert c.post("/api/v1/memory/pool-p/search", json={"query": "x"}).status_code == 200
+        finally:
+            app.state.auth_backend = prev
+
+    def test_bob_sharee_allowed_read_write_denied_delete(self, tmp_path) -> None:
+        """Bob reads/writes via alice's shared agent; delete requires ownership."""
+        self._stores(tmp_path)
+
+        # Alice creates an agent that declares pool-p and shares with *.
+        prev_alice = self._fixed_backend(_user("alice"))
+        try:
+            c_alice = TestClient(app, raise_server_exceptions=False)
+            self._create_agent(c_alice, owner_id="alice", pool="pool-p", shared_with=["*"])
+            # Bob writes a key first so the delete call has something to target.
+            # We use alice's client here because she owns the agent, but the
+            # important thing is bob's ACL on pool-p, not who seeded the data.
+            c_alice.post("/api/v1/memory/pool-p", json={"key": "k1", "content": "v"})
+        finally:
+            app.state.auth_backend = prev_alice
+
+        prev_bob = self._fixed_backend(_user("bob"))
+        try:
+            c_bob = TestClient(app, raise_server_exceptions=False)
+            # Read/write parity with the tool surface — all four ops.
+            assert c_bob.post("/api/v1/memory/pool-p", json={"key": "k2", "content": "v"}).status_code == 201
+            assert c_bob.get("/api/v1/memory/pool-p/k1").status_code == 200
+            assert c_bob.get("/api/v1/memory/pool-p").status_code == 200
+            assert c_bob.post("/api/v1/memory/pool-p/search", json={"query": "x"}).status_code == 200
+            # Delete is stricter — sharee cannot wipe the owner's data.
+            assert c_bob.delete("/api/v1/memory/pool-p/k1").status_code == 403
+        finally:
+            app.state.auth_backend = prev_bob
+
+    def test_admin_bypasses_all_checks(self, tmp_path) -> None:
+        self._stores(tmp_path)
+        prev = self._fixed_backend(_admin())
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            # No agent declares this pool; admin still gets through.
+            assert c.post("/api/v1/memory/pool-p", json={"key": "k", "content": "v"}).status_code == 201
+            assert c.delete("/api/v1/memory/pool-p/k").status_code == 204
+        finally:
+            app.state.auth_backend = prev
+
+    def test_user_scoped_namespace_unaffected(self, tmp_path) -> None:
+        """User-scoped ``:u:{self}`` namespaces skip the transitive check."""
+        self._stores(tmp_path)
+        prev = self._fixed_backend(_user("bob"))
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            ns = "agent:whatever:u:bob"
+            assert c.post(f"/api/v1/memory/{ns}", json={"key": "k", "content": "v"}).status_code == 201
+        finally:
+            app.state.auth_backend = prev

--- a/tests/unit/routes/test_teams.py
+++ b/tests/unit/routes/test_teams.py
@@ -456,3 +456,39 @@ class TestGetTeamRun:
 
         task.cancel()
         loop.close()
+
+    def test_non_admin_denied_when_run_ownership_unknown(self, teams_client: TestClient) -> None:
+        """``_require_run_owner`` default-denies on unknown ownership.
+
+        A bob who has team access (team shared_with includes him or
+        "*") and knows alice's team_run_id could otherwise read her
+        task board in a window where the ownership record was evicted
+        (e.g. replica restart without Redis event store).  The default
+        flipped from allow to deny — admins still bypass, non-admins
+        without a recorded match get 403.
+        """
+        from agentic_primitives_gateway.auth.base import AuthBackend
+        from agentic_primitives_gateway.auth.models import AuthenticatedPrincipal
+
+        # Seed a team shared with everyone, so resolve_team_spec passes
+        # and we isolate the _require_run_owner check itself.  The
+        # team is created under the noop (admin) principal, so its
+        # owner_id is "noop" — bob addresses it with the qualified
+        # ``{owner}:{name}`` form.
+        payload = {**TEAM_PAYLOAD, "shared_with": ["*"]}
+        teams_client.post("/api/v1/teams", json=payload)
+
+        class BobBackend(AuthBackend):
+            async def authenticate(self, request):
+                return AuthenticatedPrincipal(id="bob", type="user", scopes=frozenset())
+
+        prev = getattr(app.state, "auth_backend", None)
+        app.state.auth_backend = BobBackend()
+        try:
+            c = TestClient(app, raise_server_exceptions=False)
+            # Qualified team name so resolve_team_spec locates the
+            # spec bob doesn't own but has access to via shared_with.
+            resp = c.get("/api/v1/teams/noop:test-team/runs/alice-run-id")
+            assert resp.status_code == 403
+        finally:
+            app.state.auth_backend = prev


### PR DESCRIPTION
Changes

Credential resolution — three distinct modes (4ac7ec6, 0b64e45)
get_service_credentials_or_defaults previously had a single merge path that violated the contract of two of the three allow_server_credentials modes:
- Under never, partial caller creds were silently filled from operator defaults — a cross-user leak the mode is supposed to forbid.
- Under always, caller-supplied values overwrote operator defaults — the opposite of "operator controls credentials."
- provider.server_credentials_used audit events only fired on full fallback, not partial.

Rewritten into three non-overlapping branches: NEVER returns a shape-preserving dict (caller values + None for missing keys, defaults never consulted); ALWAYS ignores caller creds entirely; FALLBACK merges with caller winning and
emits the audit event whenever any key was filled from defaults.

Shared memory pool REST ACL (92a3621)
/api/v1/memory/{namespace}/* had no per-pool access check. Any authenticated caller could read/write/delete an unscoped namespace by guessing its name. Added has_transitive_pool_access + require_pool_access / require_pool_delete in
auth/access.py: a caller has access to pool P iff they can access some agent whose shared_namespaces contains P (or a team whose shared_memory_namespace == P). Delete is stricter — the caller must own a declaring spec. User-scoped
:u:{self} namespaces and admin short-circuit. Orphan pools (declared nowhere) resolve to admin-only.

X-Provider-* override allow-list (d54b518)
X-Provider-<primitive> headers let any caller re-route a primitive at request time. For memory / observability / llm / etc., that's a routing preference. For identity / policy / tools / the global X-Provider default, flipping the
backend changes what authorization rule gets enforced or what code runs — arbitrary capability escalation. Introduced _PROVIDER_OVERRIDE_ALLOWLIST (universal, no admin bypass) applied both in AuthenticationMiddleware (for headers)
and at every spec.provider_overrides application site (agents, a2a, checkpoint resume) so an agent owner can't re-inject via the user-editable spec field what the header layer already strips.

Runner trace attribution + team run default-deny (f14a775)
AgentRunner._trace_conversation now stamps user_id from the authenticated principal so observability traces are attributable per-user. TeamRunner._require_run_owner flipped from allow-on-unknown-owner to deny-on-unknown-owner — theprior default meant a missing owner_id on a run opened it to every caller.

Credential header sanitization coverage (fdd237b)
DEFAULT_REDACT_KEYS was exact-match, so new X-Cred-<Service>-<Key> headers leaked through until someone remembered to update the deny-list. SECRET_PATTERNS didn't cover the raw header-formatted values that downstream library errors
embed in tracebacks (40-char AWS secrets, opaque Authorization: values). Added REDACT_KEY_PREFIXES = ("x-cred-", "x-aws-") with x-aws-region allow-listed as public, plus three new regex patterns for the free-form text cases, plus
x-aws-access-key-id added to the exact-match set.
